### PR TITLE
Define Styling for navigation based on ftw.theming.

### DIFF
--- a/plonetheme/blueberry/theme/scss/controlpanel.scss
+++ b/plonetheme/blueberry/theme/scss/controlpanel.scss
@@ -1,45 +1,19 @@
-#content ul.configlets,  ul.configlets {
-  @include ul(plain);
-
-  li {
-    padding: 0;
-    margin: 0;
-
-    a {
-      padding: 0.4em;
-      display: block;
-      text-decoration: none;
-      @include navigationitem($portlet-navigation-bg-color);
-      &:hover {
-        text-decoration: none;
-        @include navigationitem($portlet-navigation-hover-color);
-      }
-    }
-  }
+.configlets {
+  @include list-group-interactive();
+  margin-bottom: $margin-vertical;
 }
 
-body.template-theming-controlpanel {
-  #visual-portal-wrapper {
-    @include clearfix();
-    width: $max-width-page;
-    margin: 0 auto;
-    background: #FFF;
-  }
+.template-overview-controlpanel {
 
-  #portal-column-one {
-    @extend .position-0;
-    @extend .width-4;
-    @extend .cell;
-  }
-  #portal-column-content {
-    @extend .position-4;
-    @extend .width-12;
-    @extend .cell;
-  }
-  #portal-logo { clear: both; }
+  #content > div > ul {
+    @include list-group();
 
-  #portal-searchbox,
-  #portal-footer-wrapper {
-    display: none;
+    &:last-of-type {
+      margin-bottom: $margin-vertical;
+    }
+
+    > li {
+      @include list-group-item();
+    }
   }
 }

--- a/plonetheme/blueberry/theme/scss/navigation.scss
+++ b/plonetheme/blueberry/theme/scss/navigation.scss
@@ -1,81 +1,31 @@
-$portlet-navigation-bg-color: $color-content-background !default;
-$portlet-navigation-hover-color: lighten($color-gray-dark, 97.5%) !default;
-$portlet-navigation-active-color: lighten($color-gray-dark, 95.5%) !default;
+.navTree {
+  @include list();
 
-@include declare-variables(
-  portlet-navigation-bg-color,
-  portlet-navigation-hover-color,
-  portlet-navigation-active-color);
+  > li > a {
+    padding: $padding-vertical 0;
+    display: table;
+    width: 100%;
+    text-align: left;
 
-
-
-@mixin navigationitem($color) {
-  @include borderradius();
-  background-color: $color;
-  border: 1px solid $color;
-  display: table;
-  &:hover {
-    text-decoration: none;
-  }
-  &:before {
-    display: table-cell !important;
-  }
-  > span {
-    display: table-cell;
-    padding-left: $padding-vertical;
-  }
-}
-
-
-.portlet.portletNavigationTree {
-  @include dl(plain);
-
-  border-top: 1px solid $color-gray-light;
-  border-bottom: 1px solid $color-gray-light;
-}
-
-
-ul.navTree {
-  @include ul(plain);
-  li {
-    margin-bottom: 0;
-  }
-
-  .navTreeItem {
-    display: block;
-  }
-
-  a {
-    padding: 0.4em 0;
-    display: block;
-    text-decoration: none;
-    @include navigationitem($portlet-navigation-bg-color);
-    &:hover {
-      @include navigationitem($portlet-navigation-hover-color);
-    }
-  }
-
-  a.navTreeCurrentItem, li.navTreeCurrentItem > a {
-    @include navigationitem($portlet-navigation-active-color);
-    font-weight: bold;
     &:before {
+      display: table-cell;
       font-weight: normal;
     }
-  }
 
-  @for $i from 1 through 10 {
-    &.navTreeLevel#{$i} a {
-      padding-left: $i + 1 * 1em;
+    span {
+      display: table-cell;
+      width: 100%;
     }
   }
+}
 
-  &.navTreeLevel0 > li > a{
-    padding-left: 1em;
+@for $i from 1 through 10 {
+  .navTreeLevel#{$i} > li > a {
+    padding-left: $padding-vertical * $i;
   }
+}
 
-  li.navTreeTopNode {
-    border-bottom: 1px solid $color-gray-light;
-    padding-left: 0;
-  }
-
+.navTreeTopNode a {
+  padding: $padding-vertical 0;
+  font-weight: bold;
 }


### PR DESCRIPTION
Navigation:
![bildschirmfoto 2016-02-08 um 16 34 10](https://cloud.githubusercontent.com/assets/1637820/12890004/f1156e94-ce81-11e5-8eaa-34f6bbedb5b4.png)
This is just a basic implementation. I need these changes to get on the contenttree widget.

Controlpanel:
![bildschirmfoto 2016-02-08 um 16 36 05](https://cloud.githubusercontent.com/assets/1637820/12890041/1dc29b60-ce82-11e5-9d4a-46c1f85f80bb.png)
I need these changes to get rid of the variable dependencies from the navigation.