### PR TITLE
The masthead has no height if there is no content.

### DIFF
--- a/plonetheme/blueberry/theme/scss/site/portaltop.scss
+++ b/plonetheme/blueberry/theme/scss/site/portaltop.scss
@@ -1,9 +1,10 @@
 .masthead {
-  @include clearfix();
   background-color: $color-primary;
+  height: $line-height-base + 2 * $padding-vertical;
 }
 
 #portal-top {
+  @include clearfix();
   max-width: $max-width-page;
   margin: 0 auto;
   .actionMenuHeader > a {


### PR DESCRIPTION
Fixes https://github.com/4teamwork/plonetheme.blueberry/issues/12

Apply a min-height for the masthead equal to a list element.