### PR TITLE
The current styling for visited links is too specific.

### DIFF
--- a/plonetheme/blueberry/theme/scss/content.scss
+++ b/plonetheme/blueberry/theme/scss/content.scss
@@ -4,9 +4,7 @@ $mark-broken-links: true !default;
   text-color-light,
   mark-broken-links);
 
-a,
-:link,
-:visited {
+a, :visited {
   color: $color-link;
   text-decoration: $text-decoration-link;
   font-weight: $font-weight-link;


### PR DESCRIPTION
Depends on https://github.com/4teamwork/ftw.theming/pull/36

We don't need to attach the styling to the `:link` pseudo class.
