### PR TITLE
Remove doubled layout definition of global navigation.

### DIFF
--- a/plonetheme/blueberry/theme/scss/site/layout.scss
+++ b/plonetheme/blueberry/theme/scss/site/layout.scss
@@ -96,12 +96,6 @@
   @include gridwidth(16);
 }
 
-.global-navigation {
-  @include cell();
-  @include gridposition(0);
-  @include gridwidth(12);
-}
-
 #portal-searchbox {
   @include cell();
   @include gridposition(12);


### PR DESCRIPTION
Fixes https://github.com/4teamwork/plonetheme.blueberry/issues/28