### PR TITLE
Get rid of injected `style.css` on configuration registry.

### DIFF
--- a/plonetheme/blueberry/marketing/theme/rules.xml
+++ b/plonetheme/blueberry/marketing/theme/rules.xml
@@ -33,6 +33,7 @@
     -->
     <drop content="/html/head/style[contains(text(),'keywordwidget.css')]"/>
     <drop content="/html/head/style[contains(text(),'querywidget.css')]"/>
+    <drop content="/html/head/link[contains(@href, '++resource++plone.app.registry/style.css')]"/>
     <after css:content="html > head > style.top" theme-children="/html/head"  />
     <after css:content="#portal-top style.top" theme-children="/html/head" />
     <after css:content="html > head > link, html > head > style:not(.top)" theme-children="/html/head" />

--- a/plonetheme/blueberry/standard/theme/rules.xml
+++ b/plonetheme/blueberry/standard/theme/rules.xml
@@ -33,6 +33,7 @@
     -->
     <drop content="/html/head/style[contains(text(),'keywordwidget.css')]"/>
     <drop content="/html/head/style[contains(text(),'querywidget.css')]"/>
+    <drop content="/html/head/link[contains(@href, '++resource++plone.app.registry/style.css')]"/>
     <after css:content="html > head > style.top" theme-children="/html/head"  />
     <after css:content="#portal-top style.top" theme-children="/html/head" />
     <after css:content="html > head > link, html > head > style:not(.top)" theme-children="/html/head" />


### PR DESCRIPTION
When going to the configuration registry an additional `style.css`
is loaded.
This CSS does absolutely nothing but destroying the view.

Before:
![bildschirmfoto 2016-02-19 um 15 45 43](https://cloud.githubusercontent.com/assets/1637820/13178638/4dcdee4e-d720-11e5-8bd3-d090d0a9562a.png)
After:
![bildschirmfoto 2016-02-19 um 15 48 26](https://cloud.githubusercontent.com/assets/1637820/13178641/50f7444e-d720-11e5-80e0-70dbbe86962f.png)

The input field looks still weird because no input type is set.