### PR TITLE
Always show vertical scrollbar on root element.

### DIFF
--- a/plonetheme/blueberry/scss/site/scaffolding.scss
+++ b/plonetheme/blueberry/scss/site/scaffolding.scss
@@ -2,6 +2,10 @@
   box-sizing: border-box;
 }
 
+html {
+  overflow-y: scroll;
+}
+
 body {
   @include clearfix();
   margin: 0;


### PR DESCRIPTION
Fixes https://github.com/4teamwork/plonetheme.blueberry/issues/5

In certain cases the scrollbar is jumping and the page gets a strange flickering
effect e.g. while validating a form. So to prevent this behaviour we always show
the vertical scrollbar on the `html` element.