### PR TITLE
Quick fix for mobilebuttons.

### DIFF
--- a/plonetheme/blueberry/marketing/theme/index.html
+++ b/plonetheme/blueberry/marketing/theme/index.html
@@ -48,6 +48,17 @@
           <a id="portal-logo" href="#"><img src="images/logo.png" alt="" /></a>
           <h2 class="hiddenStructure">Logo</h2>
         </div>
+        <ul class="mobileButtons">
+          <li>
+            <a href="#" id="toggle_search" title=""></a>
+          </li>
+          <li>
+            <a href="#" id="toggle_slidenavi" title=""></a>
+          </li>
+          <li>
+            <a href="#" id="toggle_subsitelangs" title="">de</a>
+          </li>
+        </ul>
         <nav class="globalnav">
           <ul id="portal-globalnav">
             <li class="">

--- a/plonetheme/blueberry/scss/style/marketing.scss
+++ b/plonetheme/blueberry/scss/style/marketing.scss
@@ -65,7 +65,13 @@ $color-top-section: $color-primary !default;
   .logo {
     @include cell();
     @include gridposition(0);
-    @include gridwidth(4);
+    @include gridwidth(16);
+
+    @include screen-small() {
+      @include gridposition(0);
+      @include gridwidth(4);
+    }
+
     margin-bottom: 0;
   }
 
@@ -79,13 +85,23 @@ $color-top-section: $color-primary !default;
 
   .globalnav {
     @include cell();
-    @include gridposition(4);
-    @include gridwidth(12);
+    @include gridposition(0);
+    @include gridwidth(16);
+    clear: both;
+
+    @include screen-small() {
+      @include gridposition(4);
+      @include gridwidth(12);
+      clear: none;
+    }
   }
 
 
   #portal-globalnav {
-    float: right;
+    @include screen-small() {
+      float: right;
+    }
+
     > li {
 
       &.selected > a {
@@ -117,6 +133,13 @@ $color-top-section: $color-primary !default;
     height: $height-banner;
     @include screen-large() {
       background-position: center center;
+    }
+  }
+
+  .mobileButtons {
+    > li > a {
+      @extend .fa-icon;
+      @include auto-text-color($color-header);
     }
   }
 }

--- a/plonetheme/blueberry/standard/theme/index.html
+++ b/plonetheme/blueberry/standard/theme/index.html
@@ -11,6 +11,17 @@
     <ul id="accesskeys" class="hiddenStructure" />
     <div class="masthead">
       <div id="portal-top">
+        <ul class="mobileButtons">
+          <li>
+            <a href="#" id="toggle_search" title=""></a>
+          </li>
+          <li>
+            <a href="#" id="toggle_slidenavi" title=""></a>
+          </li>
+          <li>
+            <a href="#" id="toggle_subsitelangs" title="">de</a>
+          </li>
+        </ul>
         <div id="portal-personaltools-wrapper">
           <dl class="actionMenu deactivated" id="portal-personaltools">
             <dt id="anon-personalbar">


### PR DESCRIPTION
Depends on https://github.com/4teamwork/ftw.mobilenavigation/pull/44
This quick fix includes the mobilebuttons from ftw.mobilenavigation. They will be removed later.

![bildschirmfoto 2016-03-08 um 10 37 07](https://cloud.githubusercontent.com/assets/1637820/13599250/3e1f64ae-e522-11e5-988c-88df538e8c95.png)
![bildschirmfoto 2016-03-08 um 10 37 15](https://cloud.githubusercontent.com/assets/1637820/13599251/3e20d154-e522-11e5-9444-ec2eb548545e.png)
![bildschirmfoto 2016-03-08 um 10 37 24](https://cloud.githubusercontent.com/assets/1637820/13599253/3e215110-e522-11e5-943a-ac88c10eb5c9.png)
![bildschirmfoto 2016-03-08 um 10 37 53](https://cloud.githubusercontent.com/assets/1637820/13599254/3e215002-e522-11e5-81ef-495d0958a61c.png)
![bildschirmfoto 2016-03-08 um 10 37 59](https://cloud.githubusercontent.com/assets/1637820/13599252/3e20d76c-e522-11e5-8f32-9d1ebd27f82b.png)
![bildschirmfoto 2016-03-08 um 11 29 31](https://cloud.githubusercontent.com/assets/1637820/13599255/3e218eaa-e522-11e5-9d42-88a55ec057a4.png)
![bildschirmfoto 2016-03-08 um 11 29 43](https://cloud.githubusercontent.com/assets/1637820/13599256/3e373066-e522-11e5-8ec9-7eb305a93e50.png)
![bildschirmfoto 2016-03-08 um 11 29 52](https://cloud.githubusercontent.com/assets/1637820/13599257/3e385d56-e522-11e5-9fcc-57b8561e9fb6.png)
![bildschirmfoto 2016-03-08 um 11 30 02](https://cloud.githubusercontent.com/assets/1637820/13599258/3e388ef2-e522-11e5-9604-09757ee9e780.png)
![bildschirmfoto 2016-03-08 um 11 30 11](https://cloud.githubusercontent.com/assets/1637820/13599259/3e392132-e522-11e5-98df-8ac3389e241a.png)

