### PR TITLE
Adjust width of datetimefield widget inputs.

### DIFF
--- a/plonetheme/blueberry/resources.zcml
+++ b/plonetheme/blueberry/resources.zcml
@@ -38,6 +38,7 @@
         <theme:scss file="scss/widgets/contenttree.scss" />
         <theme:scss file="scss/widgets/autocomplete.scss" />
         <theme:scss file="scss/widgets/upload.scss" />
+        <theme:scss file="scss/widgets/datetime.scss" />
 
         <theme:scss file="scss/contacts.scss" />
         <theme:scss file="scss/content.scss" />

--- a/plonetheme/blueberry/scss/widgets/datetime.scss
+++ b/plonetheme/blueberry/scss/widgets/datetime.scss
@@ -1,0 +1,4 @@
+.datetime-widget.datetime-field {
+  min-width: 0;
+  width: auto;
+}


### PR DESCRIPTION
Fixes https://github.com/4teamwork/plonetheme.blueberry/issues/3

Becuase the datetimefield widget contains regular input fields the min width
is set to `295px`. But the datetimefields are located next to each other so
they're going to float.

![bildschirmfoto 2016-03-08 um 14 32 50](https://cloud.githubusercontent.com/assets/1637820/13603165/8aed44c2-e53b-11e5-884f-e82b39fe29d9.png)

