### PR TITLE
Update standard theme not using container layout.

### DIFF
--- a/plonetheme/blueberry/scss/site/editbar.scss
+++ b/plonetheme/blueberry/scss/site/editbar.scss
@@ -1,8 +1,6 @@
 #edit-bar {
   @include clearfix();
   background-color: $color-edit;
-  border-top-left-radius: $border-radius-primary + 2;
-  border-top-right-radius: $border-radius-primary;
   margin-bottom: $margin-vertical;
 }
 
@@ -22,7 +20,4 @@
 #content-views {
   @include tab-list();
   float: left;
-  li:first-child a {
-    border-top-left-radius: $border-radius-primary;
-  }
 }

--- a/plonetheme/blueberry/scss/site/layout.scss
+++ b/plonetheme/blueberry/scss/site/layout.scss
@@ -17,13 +17,9 @@
 
 #header {
   @include clearfix();
-  padding-bottom: $padding-vertical * 10;
 }
 
 #columns {
-  @include row();
-  border-radius: $border-radius-primary;
-  margin-top: -$padding-vertical * 10 - $padding-vertical;
   background-color: $color-content-background;
   > .row {
     @include row();

--- a/plonetheme/blueberry/scss/style/government.scss
+++ b/plonetheme/blueberry/scss/style/government.scss
@@ -52,22 +52,11 @@
   }
 
   #header {
-    padding-bottom: 0;
     padding-top: $margin-vertical;
-    border-bottom: none;
   }
 
   #portal-personaltools-wrapper .actionMenuHeader a {
     @include auto-link-color($color-page-background);
-  }
-
-  #edit-bar {
-    border-radius: 0;
-  }
-
-  #container #columns {
-    margin-top: 0;
-    box-shadow: none;
   }
 
   #bottom-actions {
@@ -76,6 +65,9 @@
 
   #footer {
     margin-top: 0;
+    padding-top: $margin-vertical;
+    border-bottom-left-radius: $border-radius-primary;
+    border-bottom-right-radius: $border-radius-primary;
   }
 
   #ftw-footer {

--- a/plonetheme/blueberry/scss/style/standard.scss
+++ b/plonetheme/blueberry/scss/style/standard.scss
@@ -1,13 +1,5 @@
 .blueberry-standard {
 
-  #header {
-    border-bottom: $padding-vertical solid $color-primary;
-  }
-
-  #columns {
-    box-shadow: $box-shadow-secondary;
-  }
-
   #portal-globalnav {
     > li > a {
       margin-right: $margin-horizontal;

--- a/plonetheme/blueberry/standard/theme/index.html
+++ b/plonetheme/blueberry/standard/theme/index.html
@@ -100,7 +100,9 @@
         </div>
 
         <div id="columns" class="clearfix">
-          <div id="edit-bar"></div>
+          <div id="edit-bar">
+            <div class="row"></div>
+          </div>
           <div class="row">
             <div id="breadcrumbs-wrapper">
               <div id="portal-breadcrumbs">

--- a/plonetheme/blueberry/standard/theme/rules.xml
+++ b/plonetheme/blueberry/standard/theme/rules.xml
@@ -83,7 +83,7 @@
     <replace css:content="#service-navigation" css:theme="#service-navigation" />
     <replace css:content="ul.mobileButtons" css:theme="ul.mobileButtons" />
 
-    <replace css:content-children="#edit-bar" css:theme-children="#edit-bar" />
+    <replace css:content-children="#edit-bar" css:theme-children="#edit-bar > .row" />
     <rules if-content="not(//*[@id='edit-bar']/*)">
         <drop css:theme="#edit-bar" />
     </rules>


### PR DESCRIPTION
According to feedback from developers and customers the containerlayout
is not desired.
To get the container layout apply the government theme.

Government:
![screencapture-localhost-8080-plone-1458559244950](https://cloud.githubusercontent.com/assets/1637820/13917280/0edb0fde-ef60-11e5-9195-d2355b397e56.png)
![screencapture-localhost-8080-plone-1458559530176](https://cloud.githubusercontent.com/assets/1637820/13917281/0edb39f0-ef60-11e5-8d09-ca353fb900c2.png)
Standard:
![screencapture-localhost-8080-plone-1458559287803](https://cloud.githubusercontent.com/assets/1637820/13917287/14bb1a84-ef60-11e5-8133-b73c26820d24.png)
![screencapture-localhost-8080-plone-1458559309562](https://cloud.githubusercontent.com/assets/1637820/13917288/14bb621e-ef60-11e5-9894-163db315fe2b.png)
