### PR TITLE
IE11 Simplelayout overlay fix.

### DIFF
--- a/plonetheme/blueberry/scss/site/overlays.scss
+++ b/plonetheme/blueberry/scss/site/overlays.scss
@@ -107,5 +107,15 @@
   overflow: auto;
   width: 100%;
   height: 100%;
-  padding-bottom: $padding-vertical * 4 + $margin-vertical + 1em;
+
+  &:after {
+    /*
+      Add some space so that we can place the buttons (save / cancel)
+      absolutely.
+      We need to do this with an after pseudo element in order to support IE11.
+   */
+    content: "";
+    display: block;
+    height: $padding-vertical * 4 + $margin-vertical + 1em;
+  }
 }


### PR DESCRIPTION
Since we place save / cancel buttons absolutely in the overlay we need
to make sure that no content hides beneath the form buttons.

This was done with a padding, but unfortunately this is not supported by
IE 11. In order to support IE 11 we do the same with an ``:after``
pseudo element.


<img width="1380" alt="bildschirmfoto 2016-04-21 um 13 57 01" src="https://cloud.githubusercontent.com/assets/7469/14708211/95eeccbe-07c9-11e6-8870-d8933c721b98.png">


/cc @bierik 