### PR TITLE
Use different overlay sized based on predicted overlay content.

### DIFF
--- a/plonetheme/blueberry/scss/site/overlays.scss
+++ b/plonetheme/blueberry/scss/site/overlays.scss
@@ -24,34 +24,10 @@
 
 .overlay,
 .contenttreeWindow {
-  @include screen-small {
-    right: 5% !important;
-    left: 5% !important;
-  }
-
-  @include screen-medium {
-    right: 15% !important;
-    left: 15% !important;
-  }
-
-  @include screen-large {
-    right: 20% !important;
-    left: 20% !important;
-  }
+  @include overlay();
 
   z-index: 1000 !important;
-  position: fixed !important;
-  width: auto !important;
-  height: auto !important;
-  top: $margin-vertical * 5 !important;
-  right: 0 !important;
-  bottom: $margin-vertical * 5 !important;
-  left: 0 !important;
   display: none;
-  background-color: $color-content-background;
-  padding: $padding-vertical $padding-horizontal;
-  border-radius: $border-radius-primary;
-  box-shadow: $box-shadow-secondary;
 
   .close {
     @extend .fa-icon;
@@ -77,6 +53,7 @@
     }
   }
 
+
   .formControls {
     position: absolute;
     bottom: 0;
@@ -92,6 +69,26 @@
       -webkit-transform: translate3d(0, 0, 0)
     }
   }
+}
+
+.overlay-login {
+  @include overlay-small();
+}
+
+.overlay-edit {
+  @include overlay-large();
+}
+
+.overlay-add {
+  @include overlay-large();
+}
+
+.overlay-delete {
+  @include overlay-small();
+}
+
+.overlay-upload {
+  @include overlay-large();
 }
 
 #exposeMask + .contenttreeWindow {


### PR DESCRIPTION
Closes https://github.com/4teamwork/bl.web/issues/116

⚠️ Depends on: https://github.com/4teamwork/ftw.simplelayout/pull/324, https://github.com/4teamwork/ftw.theming/pull/47

Notice: Each overlay size in mobile view is a fullscreen overlay to use the entire space of a small device.

Fullscreen overlay:
![full](https://cloud.githubusercontent.com/assets/1637820/14767828/422d6630-0a30-11e6-972c-c2f8abac61e9.png)

Large overlays with different breakpoints:
![large_l](https://cloud.githubusercontent.com/assets/1637820/14767833/52145360-0a30-11e6-9950-23ed08375fa9.png)
![large_m](https://cloud.githubusercontent.com/assets/1637820/14767832/5214315a-0a30-11e6-866d-712c0d0d7d60.png)
![large_s](https://cloud.githubusercontent.com/assets/1637820/14767834/52154478-0a30-11e6-9e4a-e73160db9987.png)

Medium overlays with different breakpoints:
![medium_l](https://cloud.githubusercontent.com/assets/1637820/14767835/5c0a997e-0a30-11e6-9e7a-5c0a486b1b0d.png)
![medium_m](https://cloud.githubusercontent.com/assets/1637820/14767837/5c0d632a-0a30-11e6-85ac-312850a9a29e.png)
![medium_s](https://cloud.githubusercontent.com/assets/1637820/14767836/5c0acf16-0a30-11e6-871e-416327d2acd8.png)

Small overlays with different breakpoints:
![small_l](https://cloud.githubusercontent.com/assets/1637820/14767841/65ccd7b0-0a30-11e6-9e56-5a72db6a35ec.png)
![small_m](https://cloud.githubusercontent.com/assets/1637820/14767842/65e27d0e-0a30-11e6-82a8-8f035b6189ba.png)
![small_s](https://cloud.githubusercontent.com/assets/1637820/14767843/65ef9ad4-0a30-11e6-9a0f-7119683ad196.png)