### PR TITLE
Extend tinymce table head styles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
+- Styles all table cells (th and td) bold if they are in a thead. TinyMCE needs both ways.
+  [mathias.leimgruber]
+
 - Add manage portlets styling.
   [mathias.leimgruber]
 

--- a/plonetheme/blueberry/browser/z3cjbot/Products.TinyMCE.skins.tinymce.plugins.table.cell.htm.pt
+++ b/plonetheme/blueberry/browser/z3cjbot/Products.TinyMCE.skins.tinymce.plugins.table.cell.htm.pt
@@ -1,0 +1,110 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" i18n:domain="tinymce">
+<head>
+    <title i18n:translate="table_dlg_cell_title"></title>
+    <script type="text/javascript" src="../../tiny_mce_popup.js"></script>
+    <script type="text/javascript" src="../../utils/mctabs.js"></script>
+    <script type="text/javascript" src="../../utils/form_utils.js"></script>
+    <script type="text/javascript" src="../../utils/validate.js"></script>
+    <script type="text/javascript" src="../../utils/editable_selects.js"></script>
+    <script type="text/javascript" src="js/cell.js"></script>
+    <link href="css/cell.css" rel="stylesheet" type="text/css" />
+</head>
+<body id="tablecell" role="application">
+    <div class="dialog-wrapper" id="content">
+        <form onsubmit="updateAction();return false;" action="#">
+            <div class="tabs">
+            <ul class="formTabs">
+                            <li id="general_tab" class="current formTab firstFormTab" aria-controls="general_panel">
+                                <span><a href="javascript:mcTabs.displayTab('general_tab','general_panel');" onmousedown="return false;" class="selected" i18n:translate="table_dlg_general_tab"></a></span></li>
+                            <li id="advanced_tab" class="formTab lastFormTab" aria-controls="advanced_panel">
+                                <span><a href="javascript:mcTabs.displayTab('advanced_tab','advanced_panel');" onmousedown="return false;" i18n:translate="table_dlg_advanced_tab"></a></span></li>
+            </ul>
+            </div>
+
+            <div class="panel_wrapper">
+                <div id="general_panel" class="panel current">
+                    <fieldset class="formPanel" role="application">
+                        <div class="field">
+                            <div class="width-height">
+                                <label for="width" i18n:translate="table_dlg_width"></label>
+                                <div class="widget">
+                                    <input id="width" name="width" type="text" value="" size="4" maxlength="4" onchange="changedSize();" />
+                                </div>
+                            </div>
+                            &nbsp;x&nbsp;
+                            <div class="width-height">
+                                <label for="height" i18n:translate="table_dlg_height"></label>
+                                <div class="widget">
+                                    <input id="height" name="height" type="text" value="" size="4" maxlength="4" onchange="changedSize();" />
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- comment out due to Plone bug, fix by setting class tag -->
+                        <div class="field" style="display: none">
+                                                        <!-- align is not used in form but the JS depends on it -->
+                                            <input id="align" name="align" type="hidden" value="" />
+                            <label for="valign" i18n:translate="table_dlg_valign"></label>
+                            <div class="widget">
+                                <select id="valign" name="valign">
+                                    <option value="" i18n:translate="common_not_set"></option>
+                                    <option value="top" i18n:translate="table_dlg_align_top"></option>
+                                    <option value="middle" i18n:translate="table_dlg_align_middle"></option>
+                                    <option value="bottom" i18n:translate="table_dlg_align_bottom"></option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="field">
+                            <label for="scope" i18n:translate="table_dlg_scope"></label>
+                            <div class="widget">
+                                <select id="scope" name="scope">
+                                    <option value="" i18n:translate="common_not_set"></option>
+                                    <option value="col" i18n:translate="table_col">Column</option>
+                                    <option value="row" i18n:translate="table_row">Row</option>
+                                </select>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+
+                <div id="advanced_panel" class="panel">
+                    <fieldset class="formPanel">
+                        <div class="field" role="presentation">
+                            <label for="action" i18n:translate="table_dlg_cell_title"></label>
+                            <div class="widget">
+                                <select id="action" name="action">
+                                    <option value="cell" i18n:translate="table_dlg_cell_cell"></option>
+                                    <option value="row" i18n:translate="table_dlg_cell_row"></option>
+                                    <option value="all" i18n:translate="table_dlg_cell_all"></option>
+                                </select>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+            </div>
+
+            <div class="hiddenset">
+                <input id="id" name="id" type="text" value="" />
+                <input type="text" id="style" name="style" value="" />
+                <select id="dir" name="dir"><option value="" i18n:translate="common_not_set"></option></select>
+                <input id="lang" name="lang" type="text" value="" />
+                <input id="backgroundimage" name="backgroundimage" type="text" value="" />
+                <div id="backgroundimagebrowsercontainer"></div>
+                <input id="bordercolor" name="bordercolor" type="text" value="" />
+                <div id="bordercolor_pickcontainer"></div>
+                <input id="bgcolor" name="bgcolor" type="text" value="" />
+                <div id="bgcolor_pickcontainer"></div>
+            </div>
+
+            <div class="visualClear"><!-- --></div>
+
+            <div class="mceActionPanel">
+                    <input type="submit" id="insert" class="context" name="insert" i18n:attributes="value common_update" />
+                    <input type="button" id="cancel" class="context" name="cancel" i18n:attributes="value common_cancel" onclick="tinyMCEPopup.close();" />
+            </div>
+        </form>
+    </div>
+</body>
+</html>

--- a/plonetheme/blueberry/browser/z3cjbot/Products.TinyMCE.skins.tinymce.plugins.table.cell.htm.pt
+++ b/plonetheme/blueberry/browser/z3cjbot/Products.TinyMCE.skins.tinymce.plugins.table.cell.htm.pt
@@ -8,7 +8,11 @@
     <script type="text/javascript" src="../../utils/validate.js"></script>
     <script type="text/javascript" src="../../utils/editable_selects.js"></script>
     <script type="text/javascript" src="js/cell.js"></script>
-    <link href="css/cell.css" rel="stylesheet" type="text/css" />
+    <!-- PATCH START -->
+    <!-- <link href="css/cell.css" rel="stylesheet" type="text/css" /> -->
+    <link rel="stylesheet" type="text/css" tal:attributes="href context/theming.css/get_url" />
+    <!-- PATCH END -->
+
 </head>
 <body id="tablecell" role="application">
     <div class="dialog-wrapper" id="content">
@@ -32,7 +36,9 @@
                                     <input id="width" name="width" type="text" value="" size="4" maxlength="4" onchange="changedSize();" />
                                 </div>
                             </div>
-                            &nbsp;x&nbsp;
+                            <!-- PATCH START -->
+                            <!-- &nbsp;x&nbsp; -->
+                            <!-- PATCH END -->
                             <div class="width-height">
                                 <label for="height" i18n:translate="table_dlg_height"></label>
                                 <div class="widget">

--- a/plonetheme/blueberry/browser/z3cjbot/Products.TinyMCE.skins.tinymce.plugins.table.cell.htm.pt
+++ b/plonetheme/blueberry/browser/z3cjbot/Products.TinyMCE.skins.tinymce.plugins.table.cell.htm.pt
@@ -33,7 +33,7 @@
                             <div class="width-height">
                                 <label for="width" i18n:translate="table_dlg_width"></label>
                                 <div class="widget">
-                                    <input id="width" name="width" type="text" value="" size="4" maxlength="4" onchange="changedSize();" />
+                                    <input id="width" name="width" type="text" value="" size="6" maxlength="6" onchange="changedSize();" />
                                 </div>
                             </div>
                             <!-- PATCH START -->
@@ -42,7 +42,7 @@
                             <div class="width-height">
                                 <label for="height" i18n:translate="table_dlg_height"></label>
                                 <div class="widget">
-                                    <input id="height" name="height" type="text" value="" size="4" maxlength="4" onchange="changedSize();" />
+                                    <input id="height" name="height" type="text" value="" size="6" maxlength="6" onchange="changedSize();" />
                                 </div>
                             </div>
                         </div>

--- a/plonetheme/blueberry/browser/z3cjbot/Products.TinyMCE.skins.tinymce.plugins.table.row.htm.pt
+++ b/plonetheme/blueberry/browser/z3cjbot/Products.TinyMCE.skins.tinymce.plugins.table.row.htm.pt
@@ -1,0 +1,158 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>{#table_dlg.row_title}</title>
+    <script type="text/javascript" src="../../tiny_mce_popup.js?v={tinymce_version}"></script>
+    <script type="text/javascript" src="../../utils/mctabs.js?v={tinymce_version}"></script>
+    <script type="text/javascript" src="../../utils/form_utils.js?v={tinymce_version}"></script>
+    <script type="text/javascript" src="../../utils/validate.js?v={tinymce_version}"></script>
+    <script type="text/javascript" src="../../utils/editable_selects.js?v={tinymce_version}"></script>
+    <script type="text/javascript" src="js/row.js?v={tinymce_version}"></script>
+    <link href="css/row.css?v={tinymce_version}" rel="stylesheet" type="text/css" />
+  </head>
+  <body id="tablerow" style="display: none" role="application">
+    <div id="content" class="dialog-wrapper">
+      <form onsubmit="updateAction();return false;" action="#">
+        <div class="tabs">
+          <ul class="formTabs">
+            <li id="general_tab" class="current firstFormTab formTab" aria-controls="general_panel"><span><a class="selected" href="javascript:mcTabs.displayTab('general_tab','general_panel');" onmousedown="return false;">{#table_dlg.general_tab}</a></span></li>
+            <li id="advanced_tab" class="formTab lastFormTab" aria-controls="advanced_panel"><span><a href="javascript:mcTabs.displayTab('advanced_tab','advanced_panel');" onmousedown="return false;">{#table_dlg.advanced_tab}</a></span></li>
+          </ul>
+        </div>
+
+        <div class="panel_wrapper">
+          <div id="general_panel" class="panel current">
+            <fieldset class="formPanel">
+
+              <table role="presentation" border="0" cellpadding="4" cellspacing="0">
+                <tr>
+                  <td><label for="rowtype">{#table_dlg.rowtype}</label></td>
+                  <td class="col2">
+                    <select id="rowtype" name="rowtype" class="mceFocus" onChange="changedRowType();">
+                      <option value="thead">{#table_dlg.thead}</option>
+                      <option value="tbody">{#table_dlg.tbody}</option>
+                      <option value="tfoot">{#table_dlg.tfoot}</option>
+                    </select>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td><label for="align">{#table_dlg.align}</label></td>
+                  <td class="col2">
+                    <select id="align" name="align">
+                      <option value="">{#not_set}</option>
+                      <option value="center">{#table_dlg.align_middle}</option>
+                      <option value="left">{#table_dlg.align_left}</option>
+                      <option value="right">{#table_dlg.align_right}</option>
+                    </select>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td><label for="valign">{#table_dlg.valign}</label></td>
+                  <td class="col2">
+                    <select id="valign" name="valign">
+                      <option value="">{#not_set}</option>
+                      <option value="top">{#table_dlg.align_top}</option>
+                      <option value="middle">{#table_dlg.align_middle}</option>
+                      <option value="bottom">{#table_dlg.align_bottom}</option>
+                    </select>
+                  </td>
+                </tr>
+
+                <tr id="styleSelectRow">
+                  <td><label for="class">{#class_name}</label></td>
+                  <td class="col2">
+                    <select id="class" name="class" class="mceEditableSelect">
+                      <option value="" selected="selected">{#not_set}</option>
+                    </select>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td><label for="height">{#table_dlg.height}</label></td>
+                  <td class="col2"><input name="height" type="text" id="height" value="" size="7" maxlength="7" onchange="changedSize();" class="size" /></td>
+                </tr>
+              </table>
+            </fieldset>
+          </div>
+
+          <div id="advanced_panel" class="panel">
+            <fieldset class="formPanel">
+
+              <table role="presentation" border="0" cellpadding="0" cellspacing="4">
+                <tr>
+                  <td class="column1"><label for="id">{#table_dlg.id}</label></td>
+                  <td><input id="id" name="id" type="text" value="" style="width: 200px" /></td>
+                </tr>
+
+                <tr>
+                  <td><label for="style">{#table_dlg.style}</label></td>
+                  <td><input type="text" id="style" name="style" value="" style="width: 200px;" onchange="changedStyle();" /></td>
+                </tr>
+
+                <tr>
+                  <td class="column1"><label for="dir">{#table_dlg.langdir}</label></td>
+                  <td>
+                    <select id="dir" name="dir" style="width: 200px">
+                      <option value="">{#not_set}</option>
+                      <option value="ltr">{#table_dlg.ltr}</option>
+                      <option value="rtl">{#table_dlg.rtl}</option>
+                    </select>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td class="column1"><label for="lang">{#table_dlg.langcode}</label></td>
+                  <td>
+                    <input id="lang" name="lang" type="text" value="" style="width: 200px" />
+                  </td>
+                </tr>
+
+                <tr>
+                  <td class="column1"><label for="backgroundimage">{#table_dlg.bgimage}</label></td>
+                  <td>
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td><input id="backgroundimage" name="backgroundimage" type="text" value="" style="width: 200px" onchange="changedBackgroundImage();" /></td>
+                        <td id="backgroundimagebrowsercontainer">&nbsp;</td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td class="column1"><label for="bgcolor" id="bgcolor_label">{#table_dlg.bgcolor}</label></td>
+                  <td>
+                    <span role="group" aria-labelledby="bgcolor_label">
+                      <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                        <tr>
+                          <td><input id="bgcolor" name="bgcolor" type="text" value="" size="9" onchange="updateColor('bgcolor_pick','bgcolor');changedColor();" /></td>
+                          <td id="bgcolor_pickcontainer">&nbsp;</td>
+                        </tr>
+                      </table>
+                    </span>
+                  </td>
+                </tr>
+              </table>
+            </fieldset>
+          </div>
+        </div>
+
+        <div class="mceActionPanel">
+          <div>
+            <select id="action" name="action">
+              <option value="row">{#table_dlg.row_row}</option>
+              <option value="odd">{#table_dlg.row_odd}</option>
+              <option value="even">{#table_dlg.row_even}</option>
+              <option value="all">{#table_dlg.row_all}</option>
+            </select>
+          </div>
+
+          <input type="submit" id="insert" class="context" name="insert" value="{#update}" />
+          <input type="button" id="cancel" class="context" name="cancel" value="{#cancel}" onclick="tinyMCEPopup.close();" />
+        </div>
+      </form>
+    </div>
+  </body>
+</html>

--- a/plonetheme/blueberry/browser/z3cjbot/Products.TinyMCE.skins.tinymce.plugins.table.row.htm.pt
+++ b/plonetheme/blueberry/browser/z3cjbot/Products.TinyMCE.skins.tinymce.plugins.table.row.htm.pt
@@ -8,7 +8,12 @@
     <script type="text/javascript" src="../../utils/validate.js?v={tinymce_version}"></script>
     <script type="text/javascript" src="../../utils/editable_selects.js?v={tinymce_version}"></script>
     <script type="text/javascript" src="js/row.js?v={tinymce_version}"></script>
-    <link href="css/row.css?v={tinymce_version}" rel="stylesheet" type="text/css" />
+    <!-- PATCH START -->
+    <!--     <link href="css/row.css?v={tinymce_version}" rel="stylesheet" type="text/css" />
+     -->
+    <link rel="stylesheet" type="text/css" tal:attributes="href context/theming.css/get_url" />
+    <!-- PATCH END -->
+
   </head>
   <body id="tablerow" style="display: none" role="application">
     <div id="content" class="dialog-wrapper">

--- a/plonetheme/blueberry/scss/site/tables.scss
+++ b/plonetheme/blueberry/scss/site/tables.scss
@@ -1,5 +1,6 @@
 @mixin heading-cell() {
   border-bottom: 1px solid $color-primary;
+  font-weight: bold;
 }
 
 table {
@@ -37,7 +38,7 @@ tbody tr {
   }
 }
 
-thead tr {
+thead tr, .mceItemTable thead tr {
   th, td {
     @include heading-cell();
   }

--- a/plonetheme/blueberry/scss/tinymce.scss
+++ b/plonetheme/blueberry/scss/tinymce.scss
@@ -47,6 +47,61 @@ body.mceContentBody {
   }
 }
 
+/* TinyMCE dialog styles */
+
+.dialog-wrapper {
+
+  .formTabs {
+    @include tab-list;
+    height: 2.12em;
+    > li {
+
+      &:first-child > span > a {
+        padding-left: $padding-horizontal;
+      }
+
+      &:last-child > span > a {
+        padding-right: $padding-horizontal;
+      }
+
+      & {
+        > span > a.selected {
+          @include tab-select($color-tab-select);
+        }
+      }
+      > span > a {
+        @include tab($color-tab);
+      }
+    }
+
+  }
+
+  .mceActionPanel {
+    // Abord button
+    input[type="button"]#cancel {
+      @include button-danger;
+    }
+
+    input[type="submit"]#insert {
+      @include button-success;
+    }
+    select {
+      margin: $margin-vertical $margin-horizontal;
+    }
+  }
+
+  // Table row Panel
+  #styleSelectRow {
+    display: none; // Broken by default
+  }
+
+  // Table cell Panel
+  .hiddenset {
+    display: none;
+  }
+
+}
+
 
 /* TinyMCE styles */
 


### PR DESCRIPTION


- Make td/th bold in thead (tinymce need both)
- Style table in tinymce window more WYSIWYG.
- Style row, cell, table dialog windows of tinymce.

**This is no longer possible to achieve (table head row with different font-weights)**
<img width="620" alt="screen shot 2016-04-28 at 14 22 04" src="https://cloud.githubusercontent.com/assets/437933/14886051/0dc6796e-0d4f-11e6-8cc9-60f6edd93886.png">


**Make the red line visible in edit window**
<img width="880" alt="screen shot 2016-04-28 at 14 38 58" src="https://cloud.githubusercontent.com/assets/437933/14886077/3583026a-0d4f-11e6-95a5-02961afdf267.png">
