### PR TITLE
Move header rules into its own rules file.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Move header rules into its own rules file.
+  No longer use relative paths to inlcude the theme(index.html) file.
+  [mathias.leimgruber]
 
 
 1.1.0 (2016-05-20)

--- a/plonetheme/blueberry/baserules/configure.zcml
+++ b/plonetheme/blueberry/baserules/configure.zcml
@@ -1,0 +1,9 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="plonetheme.blueberry">
+
+    <plone:static type="theme" directory="theme" />
+
+</configure>

--- a/plonetheme/blueberry/baserules/theme/header.xml
+++ b/plonetheme/blueberry/baserules/theme/header.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules
+    xmlns="http://namespaces.plone.org/diazo"
+    xmlns:css="http://namespaces.plone.org/diazo/css"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <!-- Copy standard header tags, including base (very important for
+         Plone default pages to work correctly), meta, title and
+         style sheets/scripts, in the order they appear in the content.
+    -->
+    <drop theme="/html/head/meta" />
+    <drop theme="/html/head/title" />
+    <drop theme="/html/head/base" />
+    <drop theme="/html/head/style" />
+    <drop theme="/html/head/script" />
+    <drop theme="/html/head/link" />
+    <drop theme="/html/head/comment()" />
+
+    <after content="/html/head/meta" theme-children="/html/head" />
+    <after content="/html/head/title" theme-children="/html/head" />
+    <after content="/html/head/base | /html/head/comment()" theme-children="/html/head" />
+
+    <!-- CSS:
+         - Insert style.top-nodes at the very top, allowing to early-load custom
+           inline CSS.
+         - Make sure link / style tags are before script tags (parallel downloading)
+         - Move #portal-top link / style tags to the head before script tags
+    -->
+    <drop content="/html/head/style[contains(text(),'keywordwidget.css')]"/>
+    <drop content="/html/head/style[contains(text(),'querywidget.css')]"/>
+    <drop content="/html/head/link[contains(@href, '++resource++plone.app.registry/style.css')]"/>
+    <after css:content="html > head > style.top" theme-children="/html/head"  />
+    <after css:content="#portal-top style.top" theme-children="/html/head" />
+    <after css:content="html > head > link, html > head > style:not(.top)" theme-children="/html/head" />
+    <after css:content="#portal-top link" theme-children="/html/head" />
+    <after css:content="#portal-top style:not(.top)" theme-children="/html/head" />
+
+    <!-- JAVASCRIPT:
+         - Raven Integration JS always at top
+         - JS always after CSS
+         - external JS before embedded JS
+         - Move #portal-top script tags to the head
+    -->
+    <after content="/html/head/script[contains(text(), 'var raven_config')]" theme-children="/html/head" />
+    <after content="/html/head/script[@src]" theme-children="/html/head" />
+    <after css:content="#portal-top script[src]" theme-children="/html/head" />
+    <after content="/html/head/script[not(@src) and not(contains(text(), 'var raven_config'))]" theme-children="/html/head" />
+    <after css:content="#portal-top script:not([src])" theme-children="/html/head" />
+
+    <!-- Copy html lang -->
+    <copy attributes="lang" content="/html" theme="/html" />
+    <!-- Copy body attributes -->
+    <copy attributes="class id dir" content="/html/body" theme="/html/body" />
+
+    <replace content="/html/head/meta[@name='viewport']">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, minimum-scale=1.0" />
+    </replace>
+</rules>

--- a/plonetheme/blueberry/configure.zcml
+++ b/plonetheme/blueberry/configure.zcml
@@ -18,6 +18,7 @@
 
     <include package=".browser" />
     <include package=".viewlets" />
+    <include package=".baserules" />
     <include package=".standard" />
     <include package=".marketing" />
     <include package=".government" />

--- a/plonetheme/blueberry/government/theme/rules.xml
+++ b/plonetheme/blueberry/government/theme/rules.xml
@@ -2,64 +2,15 @@
 <rules
     xmlns="http://namespaces.plone.org/diazo"
     xmlns:css="http://namespaces.plone.org/diazo/css"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
   <!-- Rules applying to standard Plone pages -->
   <rules css:if-content="#visual-portal-wrapper">
 
-    <theme href="index.html" />
+    <theme href="/++theme++plonetheme.blueberry.government/index.html" />
 
-    <!-- Copy standard header tags, including base (very important for
-         Plone default pages to work correctly), meta, title and
-         style sheets/scripts, in the order they appear in the content.
-    -->
-    <drop theme="/html/head/meta" />
-    <drop theme="/html/head/title" />
-    <drop theme="/html/head/base" />
-    <drop theme="/html/head/style" />
-    <drop theme="/html/head/script" />
-    <drop theme="/html/head/link" />
-    <drop theme="/html/head/comment()" />
-
-    <after content="/html/head/meta" theme-children="/html/head" />
-    <after content="/html/head/title" theme-children="/html/head" />
-    <after content="/html/head/base | /html/head/comment()" theme-children="/html/head" />
-
-    <!-- CSS:
-         - Insert style.top-nodes at the very top, allowing to early-load custom
-           inline CSS.
-         - Make sure link / style tags are before script tags (parallel downloading)
-         - Move #portal-top link / style tags to the head before script tags
-    -->
-    <drop content="/html/head/style[contains(text(),'keywordwidget.css')]"/>
-    <drop content="/html/head/style[contains(text(),'querywidget.css')]"/>
-    <drop content="/html/head/link[contains(@href, '++resource++plone.app.registry/style.css')]"/>
-    <after css:content="html > head > style.top" theme-children="/html/head"  />
-    <after css:content="#portal-top style.top" theme-children="/html/head" />
-    <after css:content="html > head > link, html > head > style:not(.top)" theme-children="/html/head" />
-    <after css:content="#portal-top link" theme-children="/html/head" />
-    <after css:content="#portal-top style:not(.top)" theme-children="/html/head" />
-
-    <!-- JAVASCRIPT:
-         - Raven Integration JS always at top
-         - JS always after CSS
-         - external JS before embedded JS
-         - Move #portal-top script tags to the head
-    -->
-    <after content="/html/head/script[contains(text(), 'var raven_config')]" theme-children="/html/head" />
-    <after content="/html/head/script[@src]" theme-children="/html/head" />
-    <after css:content="#portal-top script[src]" theme-children="/html/head" />
-    <after content="/html/head/script[not(@src) and not(contains(text(), 'var raven_config'))]" theme-children="/html/head" />
-    <after css:content="#portal-top script:not([src])" theme-children="/html/head" />
-
-    <!-- Copy html lang -->
-    <copy attributes="lang" content="/html" theme="/html" />
-    <!-- Copy body attributes -->
-    <copy attributes="class id dir" content="/html/body" theme="/html/body" />
-
-    <replace content="/html/head/meta[@name='viewport']">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, minimum-scale=1.0" />
-    </replace>
+    <xi:include href="/++theme++plonetheme.blueberry.baserules/header.xml" />
 
     <replace css:content="#portal-logo" css:theme="#portal-logo" />
     <rules if-content="//*[@id='additional-logo']">

--- a/plonetheme/blueberry/marketing/theme/rules.xml
+++ b/plonetheme/blueberry/marketing/theme/rules.xml
@@ -2,64 +2,15 @@
 <rules
     xmlns="http://namespaces.plone.org/diazo"
     xmlns:css="http://namespaces.plone.org/diazo/css"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
   <!-- Rules applying to standard Plone pages -->
   <rules css:if-content="#visual-portal-wrapper">
 
-    <theme href="index.html" />
+    <theme href="/++theme++plonetheme.blueberry.marketing/index.html" />
 
-    <!-- Copy standard header tags, including base (very important for
-         Plone default pages to work correctly), meta, title and
-         style sheets/scripts, in the order they appear in the content.
-    -->
-    <drop theme="/html/head/meta" />
-    <drop theme="/html/head/title" />
-    <drop theme="/html/head/base" />
-    <drop theme="/html/head/style" />
-    <drop theme="/html/head/script" />
-    <drop theme="/html/head/link" />
-    <drop theme="/html/head/comment()" />
-
-    <after content="/html/head/meta" theme-children="/html/head" />
-    <after content="/html/head/title" theme-children="/html/head" />
-    <after content="/html/head/base | /html/head/comment()" theme-children="/html/head" />
-
-    <!-- CSS:
-         - Insert style.top-nodes at the very top, allowing to early-load custom
-           inline CSS.
-         - Make sure link / style tags are before script tags (parallel downloading)
-         - Move #portal-top link / style tags to the head before script tags
-    -->
-    <drop content="/html/head/style[contains(text(),'keywordwidget.css')]"/>
-    <drop content="/html/head/style[contains(text(),'querywidget.css')]"/>
-    <drop content="/html/head/link[contains(@href, '++resource++plone.app.registry/style.css')]"/>
-    <after css:content="html > head > style.top" theme-children="/html/head"  />
-    <after css:content="#portal-top style.top" theme-children="/html/head" />
-    <after css:content="html > head > link, html > head > style:not(.top)" theme-children="/html/head" />
-    <after css:content="#portal-top link" theme-children="/html/head" />
-    <after css:content="#portal-top style:not(.top)" theme-children="/html/head" />
-
-    <!-- JAVASCRIPT:
-         - Raven Integration JS always at top
-         - JS always after CSS
-         - external JS before embedded JS
-         - Move #portal-top script tags to the head
-    -->
-    <after content="/html/head/script[contains(text(), 'var raven_config')]" theme-children="/html/head" />
-    <after content="/html/head/script[@src]" theme-children="/html/head" />
-    <after css:content="#portal-top script[src]" theme-children="/html/head" />
-    <after content="/html/head/script[not(@src) and not(contains(text(), 'var raven_config'))]" theme-children="/html/head" />
-    <after css:content="#portal-top script:not([src])" theme-children="/html/head" />
-
-    <!-- Copy html lang -->
-    <copy attributes="lang" content="/html" theme="/html" />
-    <!-- Copy body attributes -->
-    <copy attributes="class id dir" content="/html/body" theme="/html/body" />
-
-    <replace content="/html/head/meta[@name='viewport']">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, minimum-scale=1.0" />
-    </replace>
+    <xi:include href="/++theme++plonetheme.blueberry.baserules/header.xml" />
 
     <replace css:content="#portal-logo" css:theme="#portal-logo" />
     <rules if-content="//*[@id='additional-logo']">

--- a/plonetheme/blueberry/standard/theme/rules.xml
+++ b/plonetheme/blueberry/standard/theme/rules.xml
@@ -2,64 +2,15 @@
 <rules
     xmlns="http://namespaces.plone.org/diazo"
     xmlns:css="http://namespaces.plone.org/diazo/css"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
   <!-- Rules applying to standard Plone pages -->
   <rules css:if-content="#visual-portal-wrapper">
 
-    <theme href="index.html" />
+    <theme href="/++theme++plonetheme.blueberry.standard/index.html" />
 
-    <!-- Copy standard header tags, including base (very important for
-         Plone default pages to work correctly), meta, title and
-         style sheets/scripts, in the order they appear in the content.
-    -->
-    <drop theme="/html/head/meta" />
-    <drop theme="/html/head/title" />
-    <drop theme="/html/head/base" />
-    <drop theme="/html/head/style" />
-    <drop theme="/html/head/script" />
-    <drop theme="/html/head/link" />
-    <drop theme="/html/head/comment()" />
-
-    <after content="/html/head/meta" theme-children="/html/head" />
-    <after content="/html/head/title" theme-children="/html/head" />
-    <after content="/html/head/base | /html/head/comment()" theme-children="/html/head" />
-
-    <!-- CSS:
-         - Insert style.top-nodes at the very top, allowing to early-load custom
-           inline CSS.
-         - Make sure link / style tags are before script tags (parallel downloading)
-         - Move #portal-top link / style tags to the head before script tags
-    -->
-    <drop content="/html/head/style[contains(text(),'keywordwidget.css')]"/>
-    <drop content="/html/head/style[contains(text(),'querywidget.css')]"/>
-    <drop content="/html/head/link[contains(@href, '++resource++plone.app.registry/style.css')]"/>
-    <after css:content="html > head > style.top" theme-children="/html/head"  />
-    <after css:content="#portal-top style.top" theme-children="/html/head" />
-    <after css:content="html > head > link, html > head > style:not(.top)" theme-children="/html/head" />
-    <after css:content="#portal-top link" theme-children="/html/head" />
-    <after css:content="#portal-top style:not(.top)" theme-children="/html/head" />
-
-    <!-- JAVASCRIPT:
-         - Raven Integration JS always at top
-         - JS always after CSS
-         - external JS before embedded JS
-         - Move #portal-top script tags to the head
-    -->
-    <after content="/html/head/script[contains(text(), 'var raven_config')]" theme-children="/html/head" />
-    <after content="/html/head/script[@src]" theme-children="/html/head" />
-    <after css:content="#portal-top script[src]" theme-children="/html/head" />
-    <after content="/html/head/script[not(@src) and not(contains(text(), 'var raven_config'))]" theme-children="/html/head" />
-    <after css:content="#portal-top script:not([src])" theme-children="/html/head" />
-
-    <!-- Copy html lang -->
-    <copy attributes="lang" content="/html" theme="/html" />
-    <!-- Copy body attributes -->
-    <copy attributes="class id dir" content="/html/body" theme="/html/body" />
-
-    <replace content="/html/head/meta[@name='viewport']">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, minimum-scale=1.0" />
-    </replace>
+    <xi:include href="/++theme++plonetheme.blueberry.baserules/header.xml" />
 
     <replace css:content="#portal-logo" css:theme="#portal-logo" />
     <rules if-content="//*[@id='additional-logo']">


### PR DESCRIPTION
No longer use relative paths to inlcude the theme(index.html) file.

This change mainly reduces the need of redundant rules. 
As nice side effect the header.xml (rules) can also be used in other themes/policies.