### PR TITLE
Fix contenttree widget styles: show add button + style selected item.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix contenttree widget styles: show add button + style selected item.
+  [mathias.leimgruber]
 
 
 1.1.1 (2016-05-24)

--- a/plonetheme/blueberry/scss/site/livesearch.scss
+++ b/plonetheme/blueberry/scss/site/livesearch.scss
@@ -1,6 +1,3 @@
-.searchButton {
-  @include hidden-structure();
-}
 
 .searchSection {
   display: none;
@@ -34,6 +31,10 @@
   }
   input[type="text"] {
     padding-right: 2 * $padding-vertical + 1em;
+  }
+
+  .searchButton {
+    @include hidden-structure();
   }
 }
 

--- a/plonetheme/blueberry/scss/widgets/contenttree.scss
+++ b/plonetheme/blueberry/scss/widgets/contenttree.scss
@@ -12,6 +12,11 @@
     display: table;
     width: 100%;
   }
+
+  .navTreeCurrentItem > a{
+    font-weight: bold;
+    background-color: $color-gray-light;
+  }
 }
 
 .contenttreeWindowActions {
@@ -29,3 +34,4 @@
     -webkit-transform: translate3d(0, 0, 0)
   }
 }
+


### PR DESCRIPTION
<img width="510" alt="screen shot 2016-05-26 at 08 36 32" src="https://cloud.githubusercontent.com/assets/437933/15565767/277e4ed4-231d-11e6-8583-4988ac38508b.png">
<img width="1278" alt="screen shot 2016-05-26 at 08 36 27" src="https://cloud.githubusercontent.com/assets/437933/15565768/2797902e-231d-11e6-83ba-346c11874ea6.png">
