### PR TITLE
Define minimal styling for portal language selector.

### DIFF
--- a/plonetheme/blueberry/scss/languageselector.scss
+++ b/plonetheme/blueberry/scss/languageselector.scss
@@ -1,62 +1,16 @@
-$language-selector-link-color: $color-secondary !default;
-
-
-@include declare-variables(
-  language-selector-link-color);
-
-
 #portal-languageselector-wrapper {
-  float: left;
-  width: 100%;
-
-  @include screen-large {
-      width: auto;
+  @include screen-small() {
+    display: block;
   }
+  display: none;
+  float: left;
 
-  section#portal-languageselector,
-  dl#portal-languageselector {
-    float: left;
-    width: 100%;
-    margin-left: 0;
-    @include dl(plain);
+  .actionMenuHeader {
+    a {
+      @extend .fa-icon;
+      @extend .fa-caret-down;
+      padding-right: $padding-horizontal;
 
-    dt, header {
-      &.actionMenuHeader {
-          border: 1px solid $language-selector-link-color;
-          padding-left: 0.5em;
-          margin-top: -1px;
-
-        a {
-          color: $language-selector-link-color;
-          @extend .fa-icon;
-          @extend .fa-caret-down;
-          &:before {
-            margin-left: 0.2em;
-            float: right;
-          }
-          &:after {
-            content: none;
-          }
-        }
-      }
     }
-
-    .actionMenuContent {
-      top: 0;
-      @include ul(plain);
-      margin-left:0;
-    }
-
-    @include screen-large {
-      width: auto;
-      dl, section {
-        margin-left: 0.5em;
-      }
-
-      .actionMenuContent {
-        top: auto;
-      }
-    }
-
   }
 }


### PR DESCRIPTION
The portal language selector will be reworked with ftw.mobile.
This solution is a quick fix.
The selector has been touched in
https://github.com/4teamwork/plonetheme.blueberry/commit/61a2f247b9b1cdb8b1e0b9587c881ede99d62819
but we don't know exactly what the effects should be there.
The language selector is only in use at http://sicher-ses.ch/de.
So when http://sicher-ses.ch/de will be updated before the rework
we should keep an eye on it.

Example on fcs

![bildschirmfoto 2016-05-26 um 11 15 24](https://cloud.githubusercontent.com/assets/16755391/15569816/374f685a-2333-11e6-917c-9d580e53b84a.png)
