### PR TITLE
Move font family definitions to ftw.theming.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Move font family definitions to ftw.theming
+  [Kevin Bieri]
+
 - Fix font weight of strong links.
   [Kevin Bieri]
 

--- a/plonetheme/blueberry/scss/globals/variables.scss
+++ b/plonetheme/blueberry/scss/globals/variables.scss
@@ -1,9 +1,6 @@
 /*
   Fonts
  */
-$font-family-primary: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif !default;
-$font-family-heading: $font-family-primary !default;
-$font-family-code: "Courier New", Courier, monospace !default;
 
 $color-page-background: $color-gray-light !default;
 $color-content-background: $color-white !default;
@@ -11,8 +8,5 @@ $color-content-background: $color-white !default;
 $spinner-url: "++resource++plonetheme.blueberry/images/spinner.gif";
 
 @include declare-variables(
-  font-family-primary,
-  font-family-heading,
-  font-family-code,
   color-page-background,
   color-content-background);


### PR DESCRIPTION
Closes https://github.com/4teamwork/ftw.slider/issues/61

⚠️  Depends on https://github.com/4teamwork/ftw.theming/pull/55

Some packages make use of the font family definition in the theme.
So we have to move this definition to make is compatible with other
themes which are using ftw.theming except plonetheme.blueberry