### PR TITLE
Add support for mobile menu

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Add support for ftw.mobile in standard and marketing theme.
+  [Kevin Bieri]
+
 - Define styling for users and groups.
   [Kevin Bieri]
 

--- a/plonetheme/blueberry/government/theme/rules.xml
+++ b/plonetheme/blueberry/government/theme/rules.xml
@@ -17,11 +17,6 @@
         <after css:content="#additional-logo" css:theme="#portal-logo" />
     </rules>
 
-    <replace css:content="#mobile-logo" css:theme="#mobile-logo" />
-    <rules if-content="not(//*[@id='mobile-logo']/*)">
-        <drop css:theme="#mobile-logo" />
-    </rules>
-
     <replace css:content="#portal-globalnav" css:theme="#portal-globalnav" />
     <!-- Move hidden h2 of global section too -->
     <before css:content="#portal-header > h2.hiddenStructure" css:theme="#portal-globalnav"/>
@@ -48,6 +43,10 @@
         <drop css:theme="#ftw-mobile-wrapper" />
     </rules>
 
+    <replace css:content="#mobile-logo" css:theme="#mobile-logo" />
+    <rules if-content="not(//*[@id='mobile-logo']/*)">
+        <drop css:theme="#mobile-logo" />
+    </rules>
 
     <replace css:content-children="#edit-bar" css:theme-children="#edit-bar" />
     <rules if-content="not(//*[@id='edit-bar']/*)">

--- a/plonetheme/blueberry/marketing/theme/index.html
+++ b/plonetheme/blueberry/marketing/theme/index.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <ul id="accesskeys" class="hiddenStructure" />
-    <header id="masthead" class="clearfix">
+    <header class="masthead">
       <div class="top-section">
         <div class="row">
           <div class="dachmarke">
@@ -59,22 +59,26 @@
           <a id="portal-logo" href="#"><img src="images/logo.png" alt="" /></a>
           <h2 class="hiddenStructure">Logo</h2>
         </div>
-        <nav class="globalnav">
-          <ul id="portal-globalnav">
-            <li class="">
-              <span class="wrapper"><a title="" href="#">Private</a></span>
-            </li>
-            <li class="">
-              <span class="wrapper"><a title="" href="#">Unternehmen</a></span>
-            </li>
-            <li class="plain">
-              <span class="wrapper"><a title="" href="#">Portrait</a></span>
-            </li>
-            <li class="selected">
-              <span class="wrapper"><a title="" href="#">Beh&ouml;rden</a></span>
-            </li>
-          </ul>
-        </nav>
+        <div class="navigation">
+          <div class="navigation-row">
+            <nav class="global-navigation">
+              <ul id="portal-globalnav">
+                <li class="">
+                  <span class="wrapper"><a title="" href="#">Private</a></span>
+                </li>
+                <li class="">
+                  <span class="wrapper"><a title="" href="#">Unternehmen</a></span>
+                </li>
+                <li class="plain">
+                  <span class="wrapper"><a title="" href="#">Portrait</a></span>
+                </li>
+                <li class="selected">
+                  <span class="wrapper"><a title="" href="#">Beh&ouml;rden</a></span>
+                </li>
+              </ul>
+            </nav>
+          </div>
+        </div>
         <div id="portal-searchbox">
           <form action="#search" id="livesearch0" name="searchform">
             <div class="LSBox">
@@ -86,6 +90,7 @@
         <!-- closes #header -->
       </div>
       <div class="row">
+        <div id="ftw-mobile-wrapper" />
         <div id="portal-top">
           <div id="portal-personaltools-wrapper">
             <dl class="actionMenu deactivated" id="portal-personaltools">
@@ -307,6 +312,5 @@
 
       <!-- closes #container -->
     </div>
-
   </body>
 </html>

--- a/plonetheme/blueberry/marketing/theme/rules.xml
+++ b/plonetheme/blueberry/marketing/theme/rules.xml
@@ -34,6 +34,11 @@
     <replace css:content="#service-navigation" css:theme="#service-navigation" />
     <replace css:content="ul.mobileButtons" css:theme="ul.mobileButtons" />
 
+    <replace css:content="#ftw-mobile-wrapper" css:theme="#ftw-mobile-wrapper" />
+    <rules if-content="not(//*[@id='ftw-mobile-wrapper']/*)">
+        <drop css:theme="#ftw-mobile-wrapper" />
+    </rules>
+
     <replace css:content-children="#edit-bar" css:theme-children="#edit-bar" />
     <rules if-content="not(//*[@id='edit-bar']/*)">
         <drop css:theme="#edit-bar" />

--- a/plonetheme/blueberry/resources/javascript/fixed_header.js
+++ b/plonetheme/blueberry/resources/javascript/fixed_header.js
@@ -1,7 +1,7 @@
 (function($) {
 
   function adjustHeader() {
-    $("#container").css("padding-top", $("#masthead").outerHeight());
+    $("#container").css("padding-top", $(".masthead").outerHeight());
   }
 
   $(function() {

--- a/plonetheme/blueberry/scss/site/overlays.scss
+++ b/plonetheme/blueberry/scss/site/overlays.scss
@@ -49,17 +49,15 @@
     top: - 1.5 * $padding-vertical;
     background: $color-link;
     border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    text-align: center;
     &:hover {
       @include auto-text-color($color-link-hover);
       background-color: $color-link-hover;
     }
     &:before {
-      min-width: 0 !important;
-      margin: 0 !important;
-      width: $font-size-base;
-      height: $font-size-base;
-      line-height: $font-size-base;
-      padding: $padding-vertical;
+      line-height: 40px;
     }
   }
 

--- a/plonetheme/blueberry/scss/site/overlays.scss
+++ b/plonetheme/blueberry/scss/site/overlays.scss
@@ -11,9 +11,11 @@
   height: auto !important;
   width: auto !important;
   z-index: 999 !important;
-  background: #485563; /* fallback for old browsers */
-  background: -webkit-linear-gradient(to left, #485563 , #29323c); /* Chrome 10-25, Safari 5.1-6 */
-  background: linear-gradient(to left, #485563 , #29323c); /* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
+  @include linear-gradient(
+    right,
+    #29323c,
+    #485563
+  );
 }
 
 .overlay-open {

--- a/plonetheme/blueberry/scss/site/portaltop.scss
+++ b/plonetheme/blueberry/scss/site/portaltop.scss
@@ -1,6 +1,6 @@
 .masthead {
   background-color: $color-primary;
-  height: $line-height-base + 2 * $padding-vertical;
+  min-height: $line-height-base + 2 * $padding-vertical;
   margin-bottom: $margin-vertical;
 }
 

--- a/plonetheme/blueberry/scss/style/marketing.scss
+++ b/plonetheme/blueberry/scss/style/marketing.scss
@@ -21,12 +21,25 @@ $color-top-section: $color-primary !default;
     }
   }
 
-  #masthead {
-    background-color: $color-header;
+  #anon-personalbar > a {
+    @include auto-link-color($color-header)
+  }
+
+  #offcanvas-content {
+    @include screen-large() {
+      float: none;
+    }
+    float: left;
+  }
+
+  .masthead {
+    @include screen-large() {
+      background-color: $color-header;
+    }
     position: fixed;
     width: 100%;
     top: 0;
-    z-index: 2;
+    z-index: 5;
     box-shadow: $box-shadow-secondary;
   }
 
@@ -35,8 +48,12 @@ $color-top-section: $color-primary !default;
   }
 
   #header {
-    @include row();
-    padding: 2 * $padding-vertical 0;
+    @include screen-large() {
+      @include row();
+      display: block;
+    }
+    padding-top: $padding-vertical;
+    display: none;
   }
 
   .dachmarke {
@@ -58,12 +75,11 @@ $color-top-section: $color-primary !default;
     @include cell();
     @include gridposition(0);
     @include gridwidth(16);
+  }
 
-    @include screen-small() {
-      @include gridposition(0);
-      @include gridwidth(4);
-    }
-    margin-bottom: $margin-vertical;
+  .navigation {
+    margin: 0;
+    border: 0;
   }
 
   #portal-logo {
@@ -74,24 +90,8 @@ $color-top-section: $color-primary !default;
     width: auto;
   }
 
-  .globalnav {
-    @include cell();
-    @include gridposition(0);
-    @include gridwidth(16);
-    clear: both;
-
-    @include screen-small() {
-      @include gridposition(4);
-      @include gridwidth(12);
-      clear: none;
-    }
-  }
-
-
   #portal-globalnav {
-    @include screen-small() {
-      float: right;
-    }
+    float: right;
 
     > li {
 
@@ -126,10 +126,4 @@ $color-top-section: $color-primary !default;
     @include auto-link-color($color-header);
   }
 
-  .mobileButtons {
-    > li > a {
-      @extend .fa-icon;
-      @include auto-text-color($color-header);
-    }
-  }
 }

--- a/plonetheme/blueberry/standard/theme/index.html
+++ b/plonetheme/blueberry/standard/theme/index.html
@@ -11,6 +11,8 @@
     <ul id="accesskeys" class="hiddenStructure" />
     <div class="masthead">
       <div class="row">
+        <div id="mobile-logo" />
+        <div id="ftw-mobile-wrapper" />
         <div id="portal-top">
           <ul class="mobileButtons">
             <li>

--- a/plonetheme/blueberry/standard/theme/rules.xml
+++ b/plonetheme/blueberry/standard/theme/rules.xml
@@ -34,6 +34,21 @@
     <replace css:content="#service-navigation" css:theme="#service-navigation" />
     <replace css:content="ul.mobileButtons" css:theme="ul.mobileButtons" />
 
+    <replace css:content="#ftw-mobile-wrapper" css:theme="#ftw-mobile-wrapper" />
+    <rules if-content="not(//*[@id='ftw-mobile-wrapper']/*)">
+        <drop css:theme="#ftw-mobile-wrapper" />
+    </rules>
+
+    <replace css:content="#mobile-logo" css:theme="#mobile-logo" />
+    <rules if-content="not(//*[@id='mobile-logo']/*)">
+        <drop css:theme="#mobile-logo" />
+    </rules>
+
+    <replace css:content=".mobileButtons" css:theme=".mobileButtons" />
+    <rules if-content="not(//*[@class='mobileButtons']/*)">
+        <drop css:theme=".mobileButtons" />
+    </rules>
+
     <replace css:content-children="#edit-bar" css:theme-children="#edit-bar > .row" />
     <rules if-content="not(//*[@id='edit-bar']/*)">
         <drop css:theme="#edit-bar" />


### PR DESCRIPTION
Standard Theme:
<img width="1314" alt="bildschirmfoto 2016-07-04 um 10 44 14" src="https://cloud.githubusercontent.com/assets/1637820/16555301/5b766b10-41d4-11e6-937c-0d1c6fd138ed.png">
<img width="744" alt="bildschirmfoto 2016-07-04 um 10 44 24" src="https://cloud.githubusercontent.com/assets/1637820/16555303/5b7ed642-41d4-11e6-88fb-9733beaa13e6.png">
<img width="744" alt="bildschirmfoto 2016-07-04 um 10 44 31" src="https://cloud.githubusercontent.com/assets/1637820/16555302/5b7b0c38-41d4-11e6-9aa0-a2e80e9b6c5e.png">

Government Theme:
<img width="1377" alt="bildschirmfoto 2016-07-04 um 10 43 23" src="https://cloud.githubusercontent.com/assets/1637820/16555316/6670a8a0-41d4-11e6-955f-a0aa06e4697c.png">
<img width="987" alt="bildschirmfoto 2016-07-04 um 10 43 32" src="https://cloud.githubusercontent.com/assets/1637820/16555317/66857d8e-41d4-11e6-9a43-01fc288d85b2.png">
<img width="714" alt="bildschirmfoto 2016-07-04 um 10 43 43" src="https://cloud.githubusercontent.com/assets/1637820/16555318/669297c6-41d4-11e6-85f0-3fb523c104b9.png">

Marketing Theme:
<img width="804" alt="bildschirmfoto 2016-07-04 um 10 38 52" src="https://cloud.githubusercontent.com/assets/1637820/16555335/728cb66a-41d4-11e6-9d55-378af17389a7.png">
<img width="805" alt="bildschirmfoto 2016-07-04 um 10 39 05" src="https://cloud.githubusercontent.com/assets/1637820/16555336/72a0d94c-41d4-11e6-9b52-9edb852701b9.png">
<img width="1376" alt="bildschirmfoto 2016-07-04 um 10 39 25" src="https://cloud.githubusercontent.com/assets/1637820/16555337/72ae0220-41d4-11e6-91c3-ac29aa88c8ab.png">
