### PR TITLE
Fix lists floating next to images.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.4 (unreleased)
 ------------------
 
+- Fix list styles floating next to images.
+  [Kevin Bieri]
+
 - Fix alignment of dragging hook
   Define styling for dragging indicator
   [Kevin Bieri]

--- a/plonetheme/blueberry/scss/site/typography.scss
+++ b/plonetheme/blueberry/scss/site/typography.scss
@@ -41,6 +41,18 @@ p {
   margin-top: 0;
 }
 
+.sl-block-content ul {
+    list-style-position: outside;
+    margin: 0 0 $margin-vertical ($line-height-base + $margin-horizontal);
+    padding: 0;
+
+    li {
+      position: relative;
+      left: $margin-horizontal;
+      padding-right: $margin-horizontal;
+    }
+}
+
 .documentDescription {
   margin-bottom: $margin-vertical;
   font-weight: bold;


### PR DESCRIPTION
Closes https://github.com/4teamwork/plonetheme.blueberry/issues/25

Example solution: http://jsfiddle.net/mblase75/TJELt/

Before:
![bildschirmfoto 2016-07-12 um 11 22 03](https://cloud.githubusercontent.com/assets/1637820/16762049/2979878c-4823-11e6-87ee-41d9b368c727.png)

After:
![bildschirmfoto 2016-07-12 um 11 23 46](https://cloud.githubusercontent.com/assets/1637820/16762054/2ee54b84-4823-11e6-86ff-a78239fa3570.png)