### PR TITLE
Drop support for mobile langauge selector

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,13 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
+- Drop support for mobile languageselector
+  Will be handled through ftw.mobile
+
+- Use font-awesome icons for contenttype menu
+
+  [Kevin Bieri]
+
 - Move zindex system to ftw.theming
   [Kevin Bieri]
 

--- a/plonetheme/blueberry/scss/elements/menues.scss
+++ b/plonetheme/blueberry/scss/elements/menues.scss
@@ -1,6 +1,10 @@
 #portal-personaltools-wrapper .actionMenu {
   // We need to handle the personaltools menu diffrent becuase its always above the searchbar.
   z-index: $zindex-portal-top + $zindex-dropdown;
+
+  a:before {
+    height: 0;
+  }
 }
 
 .actionMenu {

--- a/plonetheme/blueberry/scss/languageselector.scss
+++ b/plonetheme/blueberry/scss/languageselector.scss
@@ -1,8 +1,4 @@
 #portal-languageselector-wrapper {
-  @include screen-small() {
-    display: block;
-  }
-  display: none;
   float: left;
 
   .actionMenuHeader {

--- a/plonetheme/blueberry/scss/site/editbar.scss
+++ b/plonetheme/blueberry/scss/site/editbar.scss
@@ -8,11 +8,24 @@
   float: right;
 }
 
+.arrowDownAlternative {
+  display: none;
+}
+
 #contentActionMenus {
   @include list-horizontal($direction: rtl);
 
   .actionMenuHeader a {
+    @extend .fa-icon-right;
     @include auto-text-color($color-edit);
+
+    padding-right: 0;
+
+    &:after {
+      font-family: FontAwesome;
+      content: "\f107";
+      height: 0;
+    }
   }
 
 }


### PR DESCRIPTION
Personaltools menu:
![bildschirmfoto 2016-07-19 um 11 00 53](https://cloud.githubusercontent.com/assets/1637820/16946405/a270fcb6-4da9-11e6-86a3-9726c19d1aa9.png)
![bildschirmfoto 2016-07-19 um 11 10 55](https://cloud.githubusercontent.com/assets/1637820/16946406/a2717d6c-4da9-11e6-9dae-4b4a8efcfd62.png)

Contenttype menus with font-awesome icons:
![bildschirmfoto 2016-07-19 um 11 11 31](https://cloud.githubusercontent.com/assets/1637820/16946413/aac1d4b2-4da9-11e6-8c1d-a6517623390b.png)
![bildschirmfoto 2016-07-19 um 11 11 02](https://cloud.githubusercontent.com/assets/1637820/16946415/acacb1a2-4da9-11e6-94f5-3c4046f538f6.png)

