### PR TITLE
Fix selector specificity for lists in textblocks

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
+- Fix selector specificity for lists in textblocks
+  [Kevin Bieri]
+
 - Style email fields
   [Yves Siegrist]
 

--- a/plonetheme/blueberry/scss/site/typography.scss
+++ b/plonetheme/blueberry/scss/site/typography.scss
@@ -41,7 +41,7 @@ p {
   margin-top: 0;
 }
 
-.sl-block-content ul {
+.ftw-simplelayout-textblock ul {
     list-style-position: outside;
     margin: 0 0 $margin-vertical ($line-height-base + $margin-horizontal);
     padding: 0;


### PR DESCRIPTION
Closes https://github.com/4teamwork/bl.web/issues/316

The selector to fix list styles in textblock chosed in
https://github.com/4teamwork/plonetheme.blueberry/pull/79 is too
specific. So let's limit these styles only to textblocks where we
have no news listing.

Before:
![screen shot 2016-07-28 at 08 56 53](https://cloud.githubusercontent.com/assets/1637820/17203936/b319851a-54a2-11e6-98a4-5ceeacf7b5b9.png)

After:
![screen shot 2016-07-28 at 08 55 45](https://cloud.githubusercontent.com/assets/1637820/17203945/b941c2e0-54a2-11e6-9b97-cde95207f274.png)
