### PR TITLE
Fix link style in tinyMCE editor

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.4.2 (unreleased)
 ------------------
 
+- Fix link style in tinyMCE editor
+  [Kevin Bieri]
+
 - Replace fixed zindex value
   [Kevin Bieri]
 

--- a/plonetheme/blueberry/browser/z3cjbot/Products.TinyMCE.skins.tinymce.themes.advanced.skins.plone.content.css.dtml
+++ b/plonetheme/blueberry/browser/z3cjbot/Products.TinyMCE.skins.tinymce.themes.advanced.skins.plone.content.css.dtml
@@ -1,0 +1,26 @@
+.mceItemTable, .mceItemTable td, .mceItemTable th, .mceItemTable caption, .mceItemVisualAid {border: 1px dashed #BBB;}
+a.mceItemAnchor {width:12px; line-height:6px; overflow:hidden; padding-left:12px; background:url(img/items.gif) no-repeat bottom left;}
+img.mceItemAnchor {width:12px; height:12px; background:url(img/items.gif) no-repeat;}
+table {cursor:default; font-size: 100%;}
+table td, table th {cursor:text}
+ins {border-bottom:1px solid green; text-decoration: none; color:green}
+del {color:red; text-decoration:line-through}
+cite {border-bottom:1px dashed blue}
+acronym {border-bottom:1px dotted #CCC; cursor:help}
+abbr, html\:abbr {border-bottom:1px dashed #CCC; cursor:help}
+
+img:-moz-broken {-moz-force-broken-image-icon:1; width:24px; height:24px}
+font[face=mceinline] {font-family:inherit !important}
+*[contentEditable]:focus {outline:0}
+
+.mceItemMedia {border:1px dotted #cc0000; background-position:center; background-repeat:no-repeat; background-color:#ffffcc}
+.mceItemShockWave {background-image:url(../../img/shockwave.gif)}
+.mceItemFlash {background-image:url(../../img/flash.gif)}
+.mceItemQuickTime {background-image:url(../../img/quicktime.gif)}
+.mceItemWindowsMedia {background-image:url(../../img/windowsmedia.gif)}
+.mceItemRealMedia {background-image:url(../../img/realmedia.gif)}
+.mceItemVideo {background-image:url(../../img/video.gif)}
+.mceItemAudio {background-image:url(../../img/video.gif)}
+.mceItemEmbeddedAudio {background-image:url(../../img/video.gif)}
+.mceItemIframe {background-image:url(../../img/iframe.gif)}
+.mcePageBreak {display:block;border:0;width:100%;height:12px;border-top:1px dotted #ccc;margin-top:15px;background:#fff url(../../img/pagebreak.gif) no-repeat center top;}

--- a/plonetheme/blueberry/scss/tinymce.scss
+++ b/plonetheme/blueberry/scss/tinymce.scss
@@ -1,53 +1,33 @@
+.mceContentBody {
+  padding: $padding-vertical $padding-horizontal;
+}
+
 table.mceLayout {
   td.mceIframeContainer {
-    border: none;
     @include input();
     padding: 0;
-    width: 100%;
-  }
-
-  &.mceEditorFocus {
-    td.mceIframeContainer {
-      border: 1px solid $color-primary;
-      @include boxshadow(0 1px 1px transparentize($color-primary, 0.8) inset,
-                         0 0 5px transparentize($color-primary, 0.6));
-      background: $color-content-background;
-    }
+    border-bottom: 0;
   }
 
   tr.mceLast {
     td.mceStatusbar {
-      border: none;
-      #text_path_row {
-        display: none;
-      }
-      #text_resize {
-        top: -22px;
-        position: relative;
-        display: block;
-        float: right;
-      }
+      border: 1px solid $color-gray-dark;
+      border-top: 0;
     }
   }
 }
 
-body.mceContentBody {
-  padding: 0.5em;
+.ploneSkin .mceStatusbar a[id="form.widgets.text_resize"].mceResize {
+  border-top: 1px solid $color-gray-light;
+  border-left: 1px solid $color-gray-light;
+  background-position-y: -2px;
+  background-position-x: -806px;
+  width: 15px;
+}
 
-  a {
-    color: $color-link !important;
-    font-weight: $font-weight-link;
-    text-decoration: $text-decoration-link !important;
-    border-bottom: none !important;
-
-    &:hover {
-      color: $color-link-hover;
-      text-decoration: $text-decoration-link-hover;
-    }
-  }
-
-  strong a {
-    font-weight: inherit;
+.ploneSkin {
+  [id="form.widgets.text_path_row"] {
+    display: none;
   }
 }
 


### PR DESCRIPTION
The `content.css` in portal skins applies important styles to any
anchor tag in the editor.
These style break some modules e.g. `popularContent` Widget.
So we remove this part from the `content.css` by overriding the file
using z3c.jbot. With these changes we are able to drop some definitions in
the tinyMCE specific styles.

https://github.com/4teamwork/plonetheme.blueberry/compare/kb_tiny_mce_styles?expand=1#diff-de61e8246fc0c8021d17e2aa3aef762dL9: This line has been removed because the focused state is no longer working anyway.

![screen shot 2016-08-02 at 16 38 45](https://cloud.githubusercontent.com/assets/1637820/17333862/55983da6-58d4-11e6-86d7-72cfa69553eb.png)
