### PR TITLE
Fix helper position when dragging with scroll offset

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.4.3 (unreleased)
 ------------------
 
+- Fix helper position when dragging with scroll offset
+  [Kevin Bieri]
+
 - Fix JSON search in plonebrowser
   - Fix styling of plonebrowser using ftw.theming
   - Remove obsolete login overlay styling

--- a/plonetheme/blueberry/scss/site/scaffolding.scss
+++ b/plonetheme/blueberry/scss/site/scaffolding.scss
@@ -3,7 +3,6 @@
 }
 
 html {
-  overflow-y: scroll;
   font-size: $font-size-base;
 }
 


### PR DESCRIPTION
The helper had the wrong position when dragging when the page has been scrolled.

According to https://bugs.jqueryui.com/ticket/6258
setting `overflow-y: scroll;` is the issue.

@maethu updating jquery-ui did not fix the issue. I tried diffrent versions from 1.10.2 to 1.10.4.