### PR TITLE
Let variables be published by ftw.publisher.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.4.4 (unreleased)
 ------------------
 
+- Let variables be published by ftw.publisher. [jone]
+
 - Swap mobileLogo and mobileWrapper node in index.html for styling reasons
   [Kevin Bieri]
 

--- a/plonetheme/blueberry/configure.zcml
+++ b/plonetheme/blueberry/configure.zcml
@@ -23,6 +23,7 @@
     <include package=".standard" />
     <include package=".marketing" />
     <include package=".government" />
+    <include package=".publisher" zcml:condition="installed ftw.publisher.core" />
 
     <browser:resourceDirectory
         name="plonetheme.blueberry"

--- a/plonetheme/blueberry/publisher/collector.py
+++ b/plonetheme/blueberry/publisher/collector.py
@@ -1,0 +1,31 @@
+from AccessControl.SecurityInfo import ClassSecurityInformation
+from ftw.publisher.core.interfaces import IDataCollector
+from plonetheme.blueberry.browser.forms import TIMESTAMP_ANNOTATION_KEY
+from plonetheme.blueberry.browser.forms import VARIABLES_ANNOTATION_KEY
+from zope.annotation import IAnnotations
+from zope.interface import implements
+
+
+class DesignVariablesDataCollector(object):
+    implements(IDataCollector)
+    security = ClassSecurityInformation()
+
+    def __init__(self, obj):
+        self.obj = obj
+
+    security.declarePrivate('getData')
+    def getData(self):
+        annotations = IAnnotations(self.obj)
+        data = {}
+
+        if VARIABLES_ANNOTATION_KEY in annotations:
+            data[VARIABLES_ANNOTATION_KEY] = annotations[VARIABLES_ANNOTATION_KEY]
+
+        if TIMESTAMP_ANNOTATION_KEY in annotations:
+            data[TIMESTAMP_ANNOTATION_KEY] = annotations[TIMESTAMP_ANNOTATION_KEY]
+
+        return data
+
+    security.declarePrivate('setData')
+    def setData(self, data, metadata):
+        IAnnotations(self.obj).update(data)

--- a/plonetheme/blueberry/publisher/configure.zcml
+++ b/plonetheme/blueberry/publisher/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="plonetheme.blueberry">
+
+    <adapter
+        for="plone.app.layout.navigation.interfaces.INavigationRoot"
+        provides="ftw.publisher.core.interfaces.IDataCollector"
+        factory=".collector.DesignVariablesDataCollector"
+        name="plonetheme_blueberry_design_variables"
+        />
+
+</configure>

--- a/plonetheme/blueberry/tests/test_publisher.py
+++ b/plonetheme/blueberry/tests/test_publisher.py
@@ -1,0 +1,45 @@
+from ftw.publisher.core.interfaces import IDataCollector
+from persistent.mapping import PersistentMapping
+from plonetheme.blueberry.browser.forms import TIMESTAMP_ANNOTATION_KEY
+from plonetheme.blueberry.browser.forms import VARIABLES_ANNOTATION_KEY
+from plonetheme.blueberry.tests import FunctionalTestCase
+from zope.annotation import IAnnotations
+from zope.component import getAdapter
+
+
+
+class TestDesignVariablesDataCollector(FunctionalTestCase):
+
+    def test(self):
+        self.grant('Manager')
+        annotations = IAnnotations(self.portal)
+        annotations[VARIABLES_ANNOTATION_KEY] = PersistentMapping()
+        annotations[VARIABLES_ANNOTATION_KEY]['color_primary'] = {
+            'value': 'red',
+            'variable_name': '$color-primary',
+        }
+        annotations[TIMESTAMP_ANNOTATION_KEY] = 1471953385.345843
+
+        collector = getAdapter(self.portal, IDataCollector,
+                               name='plonetheme_blueberry_design_variables')
+        dump = collector.getData()
+
+        self.assertEquals(
+            {VARIABLES_ANNOTATION_KEY: {
+                'color_primary': {'value': 'red',
+                                  'variable_name': '$color-primary'}},
+             TIMESTAMP_ANNOTATION_KEY: 1471953385.345843},
+            dump)
+
+        del annotations[VARIABLES_ANNOTATION_KEY]
+        del annotations[TIMESTAMP_ANNOTATION_KEY]
+        collector.setData(dump, {})
+
+        self.assertEquals({'color_primary':
+                           {'value': 'red',
+                            'variable_name': '$color-primary'}},
+                          dict(annotations[VARIABLES_ANNOTATION_KEY]))
+        self.assertEquals(PersistentMapping,
+                          type(annotations[VARIABLES_ANNOTATION_KEY]))
+        self.assertEquals(1471953385.345843,
+                          annotations[TIMESTAMP_ANNOTATION_KEY])

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,11 @@ version = '1.4.4.dev0'
 
 tests_require = [
     'ftw.builder',
+    'ftw.publisher.core',
     'ftw.testbrowser',
     'plone.app.testing',
     'unittest2',
-    ]
+]
 
 setup(name='plonetheme.blueberry',
       version=version,


### PR DESCRIPTION
Add collection adapter for ftw.publisher in order to let the blueberry themeing variables be published by the publisher.