### PR TITLE
Swap mobileLogo and mobileWrapper node in index.html for styling reasons

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.4.4 (unreleased)
 ------------------
 
+- Swap mobileLogo and mobileWrapper node in index.html for styling reasons
+  [Kevin Bieri]
+
 - Fix external link icon
   [Kevin Bieri]
 

--- a/plonetheme/blueberry/government/theme/index.html
+++ b/plonetheme/blueberry/government/theme/index.html
@@ -11,8 +11,8 @@
     <ul id="accesskeys" class="hiddenStructure" />
     <div class="masthead">
       <div class="row">
-        <div id="mobile-logo" />
         <div id="ftw-mobile-wrapper" />
+        <div id="mobile-logo" />
         <div id="portal-top">
           <ul class="mobileButtons">
             <li>

--- a/plonetheme/blueberry/standard/theme/index.html
+++ b/plonetheme/blueberry/standard/theme/index.html
@@ -11,8 +11,8 @@
     <ul id="accesskeys" class="hiddenStructure" />
     <div class="masthead">
       <div class="row">
-        <div id="mobile-logo" />
         <div id="ftw-mobile-wrapper" />
+        <div id="mobile-logo" />
         <div id="portal-top">
           <ul class="mobileButtons">
             <li>


### PR DESCRIPTION
These changes makes the styling of the mobile logo easier