### PR TITLE
Fix toolbar actions width

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix toolbar actions width.
+  [Kevin Bieri]
 
 
 1.5.0 (2016-08-24)

--- a/plonetheme/blueberry/scss/site/typography.scss
+++ b/plonetheme/blueberry/scss/site/typography.scss
@@ -41,7 +41,7 @@ p {
   margin-top: 0;
 }
 
-.ftw-simplelayout-textblock ul {
+.ftw-simplelayout-textblock .sl-block-content ul {
     list-style-position: outside;
     margin: 0 0 $margin-vertical ($line-height-base + $margin-horizontal);
     padding: 0;


### PR DESCRIPTION
Since https://github.com/4teamwork/plonetheme.blueberry/pull/79 the appearance
of the toolbar actions are broken. So limit the list styles to the block content.

Before:
![screen shot 2016-08-29 at 16 34 02](https://cloud.githubusercontent.com/assets/1637820/18055069/d3561686-6e06-11e6-98a6-81e40cfee2f8.png)

After:
![screen shot 2016-08-29 at 16 34 18](https://cloud.githubusercontent.com/assets/1637820/18055073/d687a892-6e06-11e6-8197-8ec96d8d3305.png)
