### PR TITLE
Datagrid widget: Make datagrid actions clickable in IE11.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
+- Datagrid widget: Make datagrid actions clickable in IE11.
+  [mathias.leimgruber]
+
 - Style tel fields
   [Yves Siegrist]
 

--- a/plonetheme/blueberry/scss/widgets/datagrid.scss
+++ b/plonetheme/blueberry/scss/widgets/datagrid.scss
@@ -98,7 +98,7 @@
     width: 100%;
     height: 100%;
     position: absolute;
-    top: 0;
+    bottom: 0;
     left: 0;
     opacity: 0;
   }


### PR DESCRIPTION
In IE11 it was no really possible to add/remove/reorder rows,
since the image had the wrong height, resp. the IE11 is unable to style a 100% height.

before:
Unable to click with IE11
![unable](https://cloud.githubusercontent.com/assets/437933/18466769/4f1b4bbe-799d-11e6-9fa3-0ba977c79e6a.gif)


after:
![able](https://cloud.githubusercontent.com/assets/437933/18466775/55c99c2c-799d-11e6-84fb-0bdd926db334.gif)

