### PR TITLE
Add support for ftw.globalstatusmessage

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for ftw.globalstatusmessage.
+  [raphael-s]
 
 
 1.5.1 (2016-09-22)

--- a/plonetheme/blueberry/government/theme/index.html
+++ b/plonetheme/blueberry/government/theme/index.html
@@ -98,6 +98,8 @@
               </nav>
             </div>
           </div>
+          <div id="globalstatusmessage">
+          </div>
           <!-- closes #header -->
         </div>
 

--- a/plonetheme/blueberry/government/theme/rules.xml
+++ b/plonetheme/blueberry/government/theme/rules.xml
@@ -128,5 +128,7 @@
     <drop attributes="alt" content="//a[@id='portal-logo']/img[@alt='']" />
     <drop attributes="title" content="//a[@id='portal-logo']/img[@title='']" />
 
+    <replace css:content="#globalstatusmessage" css:theme="#globalstatusmessage" />
+
   </rules>
 </rules>

--- a/plonetheme/blueberry/marketing/theme/index.html
+++ b/plonetheme/blueberry/marketing/theme/index.html
@@ -102,6 +102,8 @@
           </div>
         </div>
       </div>
+      <div id="globalstatusmessage">
+      </div>
     </header>
     <div id="container">
       <div id="page-wrapper" class="clearfix">

--- a/plonetheme/blueberry/marketing/theme/rules.xml
+++ b/plonetheme/blueberry/marketing/theme/rules.xml
@@ -119,5 +119,7 @@
     <drop attributes="alt" content="//a[@id='portal-logo']/img[@alt='']" />
     <drop attributes="title" content="//a[@id='portal-logo']/img[@title='']" />
 
+    <replace css:content="#globalstatusmessage" css:theme="#globalstatusmessage" />
+
   </rules>
 </rules>

--- a/plonetheme/blueberry/resources.zcml
+++ b/plonetheme/blueberry/resources.zcml
@@ -17,6 +17,7 @@
         <theme:scss file="scss/elements/buttons.scss" />
         <theme:scss file="scss/elements/tabs.scss" />
         <theme:scss file="scss/elements/form.scss" />
+        <theme:scss file="scss/elements/statusmessage.scss" />
 
         <theme:scss file="scss/site/editbar.scss" />
         <theme:scss file="scss/site/portaltop.scss" />

--- a/plonetheme/blueberry/scss/elements/statusmessage.scss
+++ b/plonetheme/blueberry/scss/elements/statusmessage.scss
@@ -1,0 +1,3 @@
+#globalstatusmessage {
+    @include row();
+}

--- a/plonetheme/blueberry/scss/style/marketing.scss
+++ b/plonetheme/blueberry/scss/style/marketing.scss
@@ -39,7 +39,7 @@ $color-top-section: $color-primary !default;
     position: fixed;
     width: 100%;
     top: 0;
-    z-index: 5;
+    z-index: $zindex-dropdown + $zindex-header;
     box-shadow: $box-shadow-secondary;
   }
 
@@ -80,6 +80,11 @@ $color-top-section: $color-primary !default;
   .navigation {
     margin: 0;
     border: 0;
+    @include cell();
+    @include screen-small() {
+      @include gridposition(6);
+      @include gridwidth(10);
+    }
   }
 
   #portal-logo {

--- a/plonetheme/blueberry/standard/theme/index.html
+++ b/plonetheme/blueberry/standard/theme/index.html
@@ -98,6 +98,8 @@
               </nav>
             </div>
           </div>
+          <div id="globalstatusmessage">
+          </div>
           <!-- closes #header -->
         </div>
 

--- a/plonetheme/blueberry/standard/theme/rules.xml
+++ b/plonetheme/blueberry/standard/theme/rules.xml
@@ -129,5 +129,7 @@
     <drop attributes="alt" content="//a[@id='portal-logo']/img[@alt='']" />
     <drop attributes="title" content="//a[@id='portal-logo']/img[@title='']" />
 
+    <replace css:content="#globalstatusmessage" css:theme="#globalstatusmessage" />
+
   </rules>
 </rules>


### PR DESCRIPTION
Adds support for `ftw.globalstatusmessage` in all 3 theme-styles.

`standard`:
<img width="1227" alt="screen shot 2016-09-23 at 13 15 39" src="https://cloud.githubusercontent.com/assets/16755391/18784066/e0e17560-818f-11e6-8085-f7331ab52db9.png">

`government`:
<img width="1226" alt="screen shot 2016-09-23 at 13 14 51" src="https://cloud.githubusercontent.com/assets/16755391/18784073/e72dadda-818f-11e6-8821-2cc3682cc1d8.png">

`marketing`:
<img width="1220" alt="screen shot 2016-09-23 at 13 15 20" src="https://cloud.githubusercontent.com/assets/16755391/18784078/ef25718a-818f-11e6-98bc-3a9e4a87dbed.png">


closes https://github.com/4teamwork/ftw.globalstatusmessage/issues/19