### PR TITLE
Fix spacing on navigation elements

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,9 @@ Changelog
 - Define styling for select
   [Kevin Bieri]
 
+- Fix spacing on navigation elements
+  [Kevin Bieri]
+
 
 1.5.2 (2016-09-23)
 ------------------

--- a/plonetheme/blueberry/scss/site/navigation.scss
+++ b/plonetheme/blueberry/scss/site/navigation.scss
@@ -47,6 +47,14 @@
       border-bottom-color: $color-primary;
     }
 
+    &:first-child > a {
+      padding-left: $padding-horizontal / 2;
+    }
+
+    &:last-child > a {
+      padding-right: $padding-horizontal / 2;
+    }
+
     > a {
       @include no-link();
       font-size: $font-size-medium;


### PR DESCRIPTION
Closes https://github.com/4teamwork/plonetheme.blueberry/issues/109

Before:
<img width="1905" alt="screen shot 2016-09-29 at 16 28 28" src="https://cloud.githubusercontent.com/assets/1637820/18958225/3ce60a8e-8662-11e6-8413-cca1e83f5be6.png">

After:
<img width="1904" alt="screen shot 2016-09-29 at 16 30 09" src="https://cloud.githubusercontent.com/assets/1637820/18958228/40dd688a-8662-11e6-968b-2ec57c9ea704.png">
