### PR TITLE
Fix styled dropdown in IE

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix dropdown for Internet Explorer
+  [Kevin Bieri]
 
 
 1.6.0 (2016-10-31)

--- a/plonetheme/blueberry/scss/elements/form.scss
+++ b/plonetheme/blueberry/scss/elements/form.scss
@@ -12,6 +12,11 @@ select:-moz-focusring {
   text-shadow:0 0 0 $color-text;
 }
 
+// http://stackoverflow.com/questions/20163079/remove-select-arrow-on-ie
+select::-ms-expand {
+  display: none;
+}
+
 select {
   @include appearance();
   min-width: 0;


### PR DESCRIPTION
https://github.com/4teamwork/winterthur.web/issues/527

Internet Explorer displays the native select arrow.

Tested with EDGE, IE11 and IE10

![screen shot 2016-11-02 at 13 54 33](https://cloud.githubusercontent.com/assets/1637820/19929484/df250eba-a103-11e6-9c5b-de44b6cffeb0.png)
