### PR TITLE
Fix styling of datagridwidget

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
+- Fix styling for datagrid widget.
+  [Kevin Bieri]
+
 - Define minimal styling for document actions.
   [Kevin Bieri]
 

--- a/plonetheme/blueberry/profiles/default/cssregistry.xml
+++ b/plonetheme/blueberry/profiles/default/cssregistry.xml
@@ -31,5 +31,6 @@
     <stylesheet id="++resource++plone.formwidget.contenttree/contenttree.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
     <stylesheet id="++resource++tinymce.stylesheets/tinymce.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
     <stylesheet id="++resource++plone.formwidget.autocomplete/jquery.autocomplete.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
+    <stylesheet id="++resource++collective.z3cform.datagridfield/datagridfield.css" expression="not:request/HTTP_X_FTW_THEMING|nothing" />
 
 </object>

--- a/plonetheme/blueberry/scss/widgets/datagrid.scss
+++ b/plonetheme/blueberry/scss/widgets/datagrid.scss
@@ -6,44 +6,57 @@
 .datagridwidget-table-view {
 
   width: 100%;
+  border: 0;
+  background: none;
 
   .formControls {
     display: none;
   }
 
+  .select2.select2-container .select2-selection--single {
+    border: 0;
+  }
+
   .header {
+    font-size: em($font-size-base);
+    background-color: $color-gray-light;
+    color: $color-text;
+    padding: $padding-vertical $padding-horizontal;
+  }
+
+  label {
     padding: 0;
   }
 
-
-  input[type="text"] {
+  input[type="text"], select {
     min-width: 0;
     width: 100%;
     box-sizing: border-box;
+    border: 0;
+    padding: 0 $padding-horizontal / 2;
+
+    &:focus {
+      background-color: $color-gray-light;
+      border-color: $color-gray-dark;
+    }
+  }
+
+  input[type="checkbox"], input[type="radio"] {
+    margin-left: $padding-horizontal / 2;
+  }
+
+  input[type="button"] {
+    border-radius: 0;
   }
 
   .datagridwidget-cell {
-    vertical-align: bottom;
-  }
+    vertical-align: middle;
+    padding: 0;
+    border-left: 1px solid $color-gray-dark;
 
-  .cell-1 {
-    padding: $padding-vertical $padding-horizontal;
-    width: 20%;
-  }
-
-  .cell-2 {
-    padding: $padding-vertical $padding-horizontal;
-    width: 20%;
-  }
-
-  .cell-3 {
-    padding: $padding-vertical $padding-horizontal;
-    width: 30%;
-  }
-
-  .cell-4 {
-    padding: $padding-vertical $padding-horizontal;
-    width: 30%;
+    &:first-child {
+      border-left: 0;
+    }
   }
 
   .querySelectSearch {
@@ -69,12 +82,15 @@
   display: none;
 }
 
+.datagridwidget-empty-row { display: none; }
+
 .datagridwidget-manipulator {
   @extend .fa-icon;
   position: relative;
   padding: 0;
-  width: 0;
-  padding: 0;
+  width: 1px;
+  vertical-align: middle;
+  text-align: center;
 
   &.insert-row {
     @extend .fa-plus;
@@ -103,4 +119,16 @@
     opacity: 0;
   }
 
+}
+
+.insert-row {
+  border-left: 1px solid $color-gray-dark;
+}
+
+.auto-append  > .datagridwidget-manipulator {
+  &.insert-row, &.delete-row {
+    &:before {
+      content: none;
+    }
+  }
 }

--- a/plonetheme/blueberry/upgrades/20161221155154_remove_default_datagrid_styling/cssregisry.xml
+++ b/plonetheme/blueberry/upgrades/20161221155154_remove_default_datagrid_styling/cssregisry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<object name="portal_css" meta_type="Stylesheets Registry" autogroup="False">
+
+    <!--
+    Disable the datagridfield stylesheet if ftw.theming is installed.
+    -->
+    <stylesheet
+        id="++resource++collective.z3cform.datagridfield/datagridfield.css"
+        expression="not:request/HTTP_X_FTW_THEMING|nothing"
+        />
+
+</object>

--- a/plonetheme/blueberry/upgrades/20161221155154_remove_default_datagrid_styling/upgrade.py
+++ b/plonetheme/blueberry/upgrades/20161221155154_remove_default_datagrid_styling/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RemoveDefaultDatagridStyling(UpgradeStep):
+    """Remove default datagrid styling.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Closes https://github.com/4teamwork/plonetheme.blueberry/issues/107

The datagridwidget is not working with more than four columns.
So reduce the padding around the cells to save space and let distribute them
evenly by the browser.

ftw.book:
![screen shot 2016-12-21 at 15 33 22](https://cloud.githubusercontent.com/assets/1637820/21393087/2de4ccc4-c793-11e6-95fe-ed19d77199df.png)
![screen shot 2016-12-21 at 15 33 00](https://cloud.githubusercontent.com/assets/1637820/21393086/2de4c238-c793-11e6-8a87-4a6701448dd6.png)

ftw.servicenavigation
![screen shot 2016-12-21 at 15 32 52](https://cloud.githubusercontent.com/assets/1637820/21393088/2de5c110-c793-11e6-86bf-0a4efa1a8695.png)
![screen shot 2016-12-21 at 15 32 18](https://cloud.githubusercontent.com/assets/1637820/21393089/2de61480-c793-11e6-9764-446eec9278d4.png)
