### PR TITLE
fix TinyMCE (table) panel height.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,10 +5,12 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
+- TinyMCE (table) panels: fix height so that buttons are visible. [jone]
+
 - Enable extensive support for collective.editmodeswitcher.
   Hide all elements that are not hidden by the feature itself.
   [raphael-s]
-  
+
 - Fix styling for datagrid widget.
   [Kevin Bieri]
 

--- a/plonetheme/blueberry/scss/tinymce.scss
+++ b/plonetheme/blueberry/scss/tinymce.scss
@@ -33,7 +33,11 @@ table.mceLayout {
 
 /* TinyMCE dialog styles */
 
+#table .dialog-wrapper,
 .dialog-wrapper {
+  &#content {
+    font-size: inherit;
+  }
 
   .formTabs {
     @include tab-list;
@@ -58,6 +62,10 @@ table.mceLayout {
       }
     }
 
+  }
+
+  .panel_wrapper div.current {
+    height: auto;
   }
 
   .mceActionPanel {


### PR DESCRIPTION
The table panel height was too small, resulting in panels which had no or only partially visible buttons (cancel / save):
![bildschirmfoto 2017-01-06 um 13 52 02](https://cloud.githubusercontent.com/assets/7469/21718450/e719e360-d417-11e6-8945-4741f5105229.png)

This is solved by setting the panels height to auto, so that it auto-adjusts the height:
![bildschirmfoto 2017-01-06 um 14 09 46](https://cloud.githubusercontent.com/assets/7469/21718763/d0696396-d419-11e6-8112-335a8c61db06.png)
![bildschirmfoto 2017-01-06 um 14 09 50](https://cloud.githubusercontent.com/assets/7469/21718764/d309bde4-d419-11e6-9651-7fb2c6955b5f.png)

I've also reset the font-size so that it is consistent.