### PR TITLE
Fix calendar popup on the content_status_history" form.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix calendar popup from not showing up on the content_status_history" form.
+  [mbaechtold]
 
 
 1.8.1 (2017-01-18)

--- a/plonetheme/blueberry/scss/plone-datepicker.scss
+++ b/plonetheme/blueberry/scss/plone-datepicker.scss
@@ -18,6 +18,7 @@ body .calendar {
   border: initial;
   background: initial;
   font-size: initial;
+  z-index: $zindex-base;
 
   table {
     border: initial;


### PR DESCRIPTION
<img width="1440" alt="screenshot" src="https://cloud.githubusercontent.com/assets/28220/22336226/c7634460-e3e1-11e6-97be-6955e8e2be3a.png">