### PR TITLE
Fix sitemap styles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
+- Fix sitemap styles.
+  [Kevin Bieri]
+
 - Fix calendar popup from not showing up on the content_status_history" form.
   [mbaechtold]
 

--- a/plonetheme/blueberry/scss/content.scss
+++ b/plonetheme/blueberry/scss/content.scss
@@ -17,11 +17,6 @@ ul.listTypePlain {
   @include hidden-structure();
 }
 
-#content .visualNoMarker {
-  list-style: none;
-  margin-left: 0;
-}
-
 dl.collapsible {
   dt {
     cursor: pointer;


### PR DESCRIPTION
Because the `list-style` property is applied to all visualNoMarker
elements which includes the `ul` and `li` tags, it is nearly impossible to
override these styles.

It is also uncommon to apply list styles on `li` elements. These styles
are inherited from the parent `ul` anyway.

Before:
![screen shot 2017-02-16 at 10 48 09](https://cloud.githubusercontent.com/assets/1637820/23016041/6b4d1ca0-f435-11e6-9dab-d7fb5c504131.png)

Here is an example how it might look like without these styles:
![screen shot 2017-02-16 at 10 38 38](https://cloud.githubusercontent.com/assets/1637820/23015834/9658602c-f434-11e6-87fb-b4708fc741b8.png)
