### PR TITLE
Make document actions more discreet.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
+- Make document actions more discreet.
+  [Kevin Bieri]
+
 - Fix sitemap styles.
   [Kevin Bieri]
 

--- a/plonetheme/blueberry/scss/site/documentactions.scss
+++ b/plonetheme/blueberry/scss/site/documentactions.scss
@@ -1,12 +1,9 @@
-#document-actions > ul {
-  @include clearfix();
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
+#document-actions {
   margin-bottom: $margin-vertical;
 
-  > li > a {
-    @include button();
-    float: right;
+
+  > ul {
+    @include list-horizontal($direction: rtl);
+    border-bottom: 1px solid $color-gray-dark;
   }
 }


### PR DESCRIPTION
Several customer complained about the huge document actions.
So let's make them smaller and more discreet.

## Before
<img width="1335" alt="screen shot 2017-02-16 at 14 14 17" src="https://cloud.githubusercontent.com/assets/20790360/22933539/2cc8db96-f2cc-11e6-99cc-dde50670c2f5.png">

## After
<img width="1335" alt="screen shot 2017-02-16 at 14 14 17" src="https://cloud.githubusercontent.com/assets/1637820/23023199/a734d5ae-f454-11e6-8538-fb680dada52a.png">
