### PR TITLE
Force all columns to use the full page in print mode.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.8.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- [print] Force columns to use the full page.
+  [Kevin Bieri]
 
 
 1.8.2 (2017-02-28)

--- a/plonetheme/blueberry/scss/print.scss
+++ b/plonetheme/blueberry/scss/print.scss
@@ -113,9 +113,13 @@
     margin: 0;
   }
 
-  #column-content {
-    margin-left: -100%;
-    width: 100%;
+  // Force the columns to use the full width
+  #column-content,
+  #column-sidebar {
+    float: none !important;
+    position: static !important;
+    margin-left: 0 !important;
+    width: 100% !important;
   }
 
 
@@ -154,7 +158,13 @@
     max-width: none;
   }
 
+  html, body {
+    width: 210mm;
+    height: 297mm;
+  }
+
   @page {
+    size: A4;
     margin: 2.5cm 2.5cm 2cm;
   }
 


### PR DESCRIPTION
In print mode the columns should use the full page because chrome
reacts on screen media queries in print mode as well. So force all columns
to use the full page width.

Additionally define the size of the printed page to be a DIN A4. Also make these
restrictions on the HTML and body tag.