### PR TITLE
Restyle sitemap

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 
 - Fix single status in editbar.
   [Kevin Bieri]
+- Restyle sitemap !this may break some custom sitemap-stylings!
+  [raphael-s]
 
 
 1.8.3 (2017-03-03)

--- a/plonetheme/blueberry/scss/site/sitemap.scss
+++ b/plonetheme/blueberry/scss/site/sitemap.scss
@@ -1,13 +1,17 @@
-.template-sitemap {
-  #portal-sitemap {
-    a:before { content: none; }
-    @include list();
-    &.navTreeLevel0 > li > div > a {
-      font-size: $font-size-medium;
-      color: $color-text;
-      margin-top: $margin-heading-vertical;
-      display: block;
-    }
-  }
+#portal-sitemap {
+    > li {
+        margin-bottom: $margin-vertical / 2;
 
+        > div > a {
+            font-size: $font-size-medium;
+        }
+    }
+
+    .navTree {
+        list-style-type: inherit;
+        padding-left: $padding-horizontal;
+        > li {
+            display: list-item;
+        }
+    }
 }


### PR DESCRIPTION
Restyles the plone sitemap view. 

<img width="1175" alt="screen shot 2017-03-03 at 14 47 08" src="https://cloud.githubusercontent.com/assets/16755391/23553503/512c8f16-0021-11e7-9478-346be72ddbb9.png">

This may cause some problems for projects which had this view overwritten by themselves.