### PR TITLE
Fix single status in editbar.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.8.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix single status in editbar.
+  [Kevin Bieri]
 
 
 1.8.3 (2017-03-03)

--- a/plonetheme/blueberry/scss/elements/menues.scss
+++ b/plonetheme/blueberry/scss/elements/menues.scss
@@ -20,10 +20,17 @@
     }
   }
 }
-.actionMenuHeader a {
-  @include no-link();
-  display: block;
-  padding: $padding-vertical $padding-horizontal;
+.actionMenuHeader {
+  a {
+    @include no-link();
+    display: block;
+    padding: $padding-vertical $padding-horizontal;
+  }
+  .noMenuAction {
+    @include auto-text-color($color-edit);
+    display: block;
+    padding: $padding-vertical $padding-horizontal;
+  }
 }
 .actionMenuContent {
   margin: 0;


### PR DESCRIPTION
When just one status is available in the editbar the styling
is broken.

![screen shot 2017-03-15 at 08 52 28](https://cloud.githubusercontent.com/assets/1637820/23938658/81004116-095d-11e7-827c-c10613c58f3e.png)
