### PR TITLE
Truncate placeholder overflow using ellipsis.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.8.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Truncate placeholder overflow using ellipsis.
+  [Kevin Bieri]
 
 
 1.8.4 (2017-03-17)

--- a/plonetheme/blueberry/scss/elements/form.scss
+++ b/plonetheme/blueberry/scss/elements/form.scss
@@ -140,3 +140,10 @@ label, .label {
     }
   }
 }
+
+input[placeholder] { text-overflow: ellipsis; }
+::-webkit-input-placeholder
+:-ms-input-placeholder
+::-ms-input-placeholder {
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
Solution taken here: https://davidwalsh.name/placeholder-overflow

Works fine in Firefox, Safari, Chrome
Unfortunately IE and Edge does not support ellipsizing the placeholder pseudo element. -> http://stackoverflow.com/questions/10556365/is-it-possible-to-ellipsize-placeholders-watermarks-in-html5

Chrome, Safari and Firefox look the same:
<img width="1239" alt="screen shot 2017-03-23 at 15 53 36" src="https://cloud.githubusercontent.com/assets/1637820/24255100/dc7a3406-0fe4-11e7-9753-95133e286987.png">

IE and Edge does not support ellipsis:
![unbenannt](https://cloud.githubusercontent.com/assets/1637820/24255205/17aa84cc-0fe5-11e7-9867-178078936fd2.png)
