### PR TITLE
Move simplelayout specific print styles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.8.6 (unreleased)
 ------------------
 
+- Move simplelayout specific print styles. [Kevin Bieri]
+
 - Style inuput type url like all other input fields.
   [mathias.leimgruber]
 

--- a/plonetheme/blueberry/scss/print.scss
+++ b/plonetheme/blueberry/scss/print.scss
@@ -45,14 +45,6 @@
     display: none !important;
   }
 
-  .sl-toolbox {
-    display: none;
-  }
-
-  .sl-toolbar-block, .sl-toolbar-layout {
-    display: none;
-  }
-
   .sliderWrapper {
     display: none;
   }


### PR DESCRIPTION
These print styles has been injected accidentally.
They should be placed in the simplelayout.

See https://github.com/4teamwork/ftw.simplelayout/commit/f4209fe9da08f8b3196f478f436a3a41963f0f3e