### PR TITLE
Enable the injection of custom HTML after the main navigation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.8.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Enable the injection of custom HTML after the main navigation. [mbaechtold]
 
 
 1.8.6 (2018-01-25)

--- a/plonetheme/blueberry/government/theme/rules.xml
+++ b/plonetheme/blueberry/government/theme/rules.xml
@@ -15,6 +15,10 @@
     <replace css:content="#portal-logo" css:theme="#portal-logo" />
 
     <replace css:content="#portal-globalnav" css:theme="#portal-globalnav" />
+
+    <!-- Enable the injection of custom HTML after the main navigation. -->
+    <after css:content=".global-navigation-additional" css:theme=".global-navigation > *" />
+
     <!-- Move hidden h2 of global section too -->
     <before css:content="#portal-header > h2.hiddenStructure" css:theme="#portal-globalnav"/>
 

--- a/plonetheme/blueberry/marketing/theme/rules.xml
+++ b/plonetheme/blueberry/marketing/theme/rules.xml
@@ -15,6 +15,10 @@
     <replace css:content="#portal-logo" css:theme="#portal-logo" />
 
     <replace css:content="#portal-globalnav" css:theme="#portal-globalnav" />
+
+    <!-- Enable the injection of custom HTML after the main navigation. -->
+    <after css:content=".global-navigation-additional" css:theme=".global-navigation > *" />
+
     <!-- Move hidden h2 of global section too -->
     <before css:content="#portal-header > h2.hiddenStructure" css:theme="#portal-globalnav"/>
 

--- a/plonetheme/blueberry/standard/theme/rules.xml
+++ b/plonetheme/blueberry/standard/theme/rules.xml
@@ -15,6 +15,10 @@
     <replace css:content="#portal-logo" css:theme="#portal-logo" />
 
     <replace css:content="#portal-globalnav" css:theme="#portal-globalnav" />
+
+    <!-- Enable the injection of custom HTML after the main navigation. -->
+    <after css:content=".global-navigation-additional" css:theme=".global-navigation > *" />
+
     <!-- Move hidden h2 of global section too -->
     <before css:content="#portal-header > h2.hiddenStructure" css:theme="#portal-globalnav"/>
 


### PR DESCRIPTION
Content in an element having the CSS class `.global-navigation-additional` gets injected after the element having the class `.global-navigation`.