### PR TITLE
Improve styling of thedatagrid widget.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.11.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Improve datagrid widget styling. [jone]
 
 
 1.11.0 (2019-03-06)

--- a/plonetheme/blueberry/scss/widgets/datagrid.scss
+++ b/plonetheme/blueberry/scss/widgets/datagrid.scss
@@ -1,12 +1,7 @@
-/*
-  Styling this widget was a pain #tableflip.
-  (╯°□°)╯︵ ┻━━━━━━┻
- */
-
 .datagridwidget-table-view {
 
   width: 100%;
-  border: 0;
+  border: 1px solid $color-gray-dark;
   background: none;
 
   .formControls {
@@ -22,6 +17,12 @@
     background-color: $color-gray-light;
     color: $color-text;
     padding: $padding-vertical $padding-horizontal;
+    border-bottom: 1px solid $color-gray-dark;
+    border-left: 1px solid $color-gray-dark;
+
+    &:last-child {
+      border-left: none;
+    }
   }
 
   label {
@@ -125,10 +126,12 @@
   border-left: 1px solid $color-gray-dark;
 }
 
+// Disable "delete" action for auto-append column: it is used for inserting
+// new columns and should therefore not be removable.
 .auto-append  > .datagridwidget-manipulator {
-  &.insert-row, &.delete-row {
-    &:before {
-      content: none;
+  &.delete-row {
+    &:before, a {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
Impove the styling of the datagrid widget.

- improve border styling and header styling
- show the `+` action of the auto-insert column: it can be used to add many rows on an empty table
- remove the `-` from the auto-insert column: it was only not shown but has worked anyway when clicked. it should not be used since the auto-insert column should always exist in order to add a new column.

before:
<img width="1408" alt="Bildschirmfoto 2019-05-20 um 16 07 47" src="https://user-images.githubusercontent.com/7469/58028275-a9d22b00-7b1a-11e9-93e7-68b182960fec.png">

after:
<img width="1408" alt="Bildschirmfoto 2019-05-20 um 16 13 34" src="https://user-images.githubusercontent.com/7469/58028266-a2ab1d00-7b1a-11e9-8639-c5e15ba8bf7b.png">
