### PR TITLE
Change link for customizing design

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.11.1 (unreleased)
 -------------------
 
+- Fix: Link to custom design now points to correct location. [busykoala]
 - Improve datagrid widget styling. [jone]
 
 

--- a/plonetheme/blueberry/profiles/default/actions.xml
+++ b/plonetheme/blueberry/profiles/default/actions.xml
@@ -6,7 +6,7 @@
         <object name="manage-theme" meta_type="CMF Action"
                 i18n:domain="plonetheme.blueberry">
             <property name="title" i18n:translate="">Customize design</property>
-            <property name="url_expr">string:@@manage-theme</property>
+            <property name="url_expr">string:${globals_view/navigationRootUrl}/@@manage-theme</property>
             <property name="icon_expr"></property>
             <property name="available_expr">python:checkPermission("plonetheme.blueberry: Customize Design Variables", object) and context.restrictedTraverse('@@plone_context_state').canonical_object().restrictedTraverse('@@plone_interface_info').provides('plone.app.layout.navigation.interfaces.INavigationRoot') and not context.REQUEST.get('_disable_editmode')</property>
             <property name="permissions">

--- a/plonetheme/blueberry/tests/test_custom_scss_variables.py
+++ b/plonetheme/blueberry/tests/test_custom_scss_variables.py
@@ -110,7 +110,7 @@ class TestCustomSCSSVariables(FunctionalTestCase):
     @browsing
     def test_user_action(self, browser):
         action_link_label = 'Customize design'
-        action_link_url = '@@manage-theme'
+        action_link_url = 'http://nohost/plone/@@manage-theme'
 
         # Make sure the manager
         browser.login().visit(self.portal)

--- a/plonetheme/blueberry/upgrades/20190612144615_change_link_for_custom_design_view/actions.xml
+++ b/plonetheme/blueberry/upgrades/20190612144615_change_link_for_custom_design_view/actions.xml
@@ -1,0 +1,13 @@
+<object meta_type="Plone Actions Tool"
+        name="portal_actions"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+    <object name="site_actions" meta_type="CMF Action Category">
+        <object name="manage-theme" meta_type="CMF Action"
+                i18n:domain="plonetheme.blueberry"
+                purge="False">
+            <property name="url_expr">string:${globals_view/navigationRootUrl}/@@manage-theme</property>
+        </object>
+    </object>
+
+</object>

--- a/plonetheme/blueberry/upgrades/20190612144615_change_link_for_custom_design_view/upgrade.py
+++ b/plonetheme/blueberry/upgrades/20190612144615_change_link_for_custom_design_view/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ChangeLinkForCustomDesignView(UpgradeStep):
+    """Change link for custom design view.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Close https://github.com/4teamwork/demo51.web/issues/8

The link to change the page was on the root instead of it being on the current pages root.
With this change this will be changed so that the link is working.