### PR TITLE
Fix footer rule, since the markup is different.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.11.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix footer rule, since the markup is different. [mathias.leimgruber]
 
 
 1.11.1 (2019-07-05)

--- a/plonetheme/blueberry/government/theme/rules.xml
+++ b/plonetheme/blueberry/government/theme/rules.xml
@@ -116,10 +116,16 @@
 
     <replace css:content="#ftw-footer" css:theme-children="#footer" />
 
-    <!-- Insert content from IPortalFooter viewlet (analytics JS and custom footer viewlets) -->
-    <after css:content="#portal-footer-wrapper > div >*:not(#portal-footer):not(#portal-colophon):not(#portal-siteactions):not(#ftw-footer)"
-           css:theme="#bottom-actions" />
-
+    <!-- Insert content from IPortalFooter viewlet (analytics JS and custom footer viewlets) Plone 4 -->
+    <rules if-content="not(//footer)">
+        <after css:content="#portal-footer-wrapper > div >*:not(#portal-footer):not(#portal-colophon):not(#portal-siteactions):not(#ftw-footer)"
+               css:theme="#bottom-actions" />
+    </rules>
+    <!-- Insert content from IPortalFooter viewlet (analytics JS and custom footer viewlets) Plone 5 -->
+    <rules if-content="//footer">
+        <after css:content="#portal-footer-wrapper >*:not(#portal-footer):not(#portal-colophon):not(#portal-siteactions):not(#ftw-footer)"
+               css:theme="#bottom-actions" />
+    </rules>
 
     <replace css:content="#portal-siteactions" css:theme="#portal-siteactions" />
 

--- a/plonetheme/blueberry/marketing/theme/rules.xml
+++ b/plonetheme/blueberry/marketing/theme/rules.xml
@@ -106,9 +106,16 @@
 
     <replace css:content="#ftw-footer" css:theme-children="#footer" />
 
-    <!-- Insert content from IPortalFooter viewlet (analytics JS and custom footer viewlets) -->
-    <after css:content="#portal-footer-wrapper > div >*:not(#portal-footer):not(#portal-colophon):not(#portal-siteactions):not(#ftw-footer)"
-           css:theme="#bottom-actions" />
+    <!-- Insert content from IPortalFooter viewlet (analytics JS and custom footer viewlets) Plone 4 -->
+    <rules if-content="not(//footer)">
+        <after css:content="#portal-footer-wrapper > div >*:not(#portal-footer):not(#portal-colophon):not(#portal-siteactions):not(#ftw-footer)"
+               css:theme="#bottom-actions" />
+    </rules>
+    <!-- Insert content from IPortalFooter viewlet (analytics JS and custom footer viewlets) Plone 5 -->
+    <rules if-content="//footer">
+        <after css:content="#portal-footer-wrapper >*:not(#portal-footer):not(#portal-colophon):not(#portal-siteactions):not(#ftw-footer)"
+               css:theme="#bottom-actions" />
+    </rules>
 
 
     <replace css:content="#portal-siteactions" css:theme="#portal-siteactions" />

--- a/plonetheme/blueberry/standard/theme/rules.xml
+++ b/plonetheme/blueberry/standard/theme/rules.xml
@@ -116,9 +116,17 @@
 
     <replace css:content="#ftw-footer" css:theme-children="#footer" />
 
-    <!-- Insert content from IPortalFooter viewlet (analytics JS and custom footer viewlets) -->
-    <after css:content="#portal-footer-wrapper > div >*:not(#portal-footer):not(#portal-colophon):not(#portal-siteactions):not(#ftw-footer)"
-           css:theme="#bottom-actions" />
+    <!-- Insert content from IPortalFooter viewlet (analytics JS and custom footer viewlets) Plone 4 -->
+    <rules if-content="not(//footer)">
+        <after css:content="#portal-footer-wrapper > div >*:not(#portal-footer):not(#portal-colophon):not(#portal-siteactions):not(#ftw-footer)"
+               css:theme="#bottom-actions" />
+    </rules>
+    <!-- Insert content from IPortalFooter viewlet (analytics JS and custom footer viewlets) Plone 5 -->
+    <rules if-content="//footer">
+        <after css:content="#portal-footer-wrapper >*:not(#portal-footer):not(#portal-colophon):not(#portal-siteactions):not(#ftw-footer)"
+               css:theme="#bottom-actions" />
+    </rules>
+
 
 
     <replace css:content="#portal-siteactions" css:theme="#portal-siteactions" />


### PR DESCRIPTION
There is a additional div in plone 4 and it's in a footer tag.

Before: 
<img width="1566" alt="Screen Shot 2020-05-28 at 10 24 08" src="https://user-images.githubusercontent.com/437933/83118960-5c927d00-a0cf-11ea-8c15-66329e74f1c4.png">


After:
<img width="1441" alt="Screen Shot 2020-05-28 at 10 38 58" src="https://user-images.githubusercontent.com/437933/83119026-7a5fe200-a0cf-11ea-87dd-36909a06ef08.png">
