### PR TITLE
Restore globalstatusmessage for plone5

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 -------------------
 
 - Fix footer rule, since the markup is different. [mathias.leimgruber]
+- Restore globalstatusmessages which were hidden for (at least some) parts of Plone 5. [djowett-ftw]
 
 
 1.11.1 (2019-07-05)

--- a/plonetheme/blueberry/government/theme/rules.xml
+++ b/plonetheme/blueberry/government/theme/rules.xml
@@ -142,7 +142,10 @@
     <drop attributes="alt" content="//a[@id='portal-logo']/img[@alt='']" />
     <drop attributes="title" content="//a[@id='portal-logo']/img[@title='']" />
 
+    <!-- status messages from Plone 4 and ftw.globalstatusmessage -->
     <replace css:content="#globalstatusmessage" css:theme="#globalstatusmessage" />
+    <!-- status messages from Plone 5 -->
+    <after css:content-children="#global_statusmessage" css:theme="#globalstatusmessage" />
 
   </rules>
 </rules>

--- a/plonetheme/blueberry/marketing/theme/rules.xml
+++ b/plonetheme/blueberry/marketing/theme/rules.xml
@@ -133,7 +133,10 @@
     <drop attributes="alt" content="//a[@id='portal-logo']/img[@alt='']" />
     <drop attributes="title" content="//a[@id='portal-logo']/img[@title='']" />
 
+    <!-- status messages from Plone 4 and ftw.globalstatusmessage -->
     <replace css:content="#globalstatusmessage" css:theme="#globalstatusmessage" />
+    <!-- status messages from Plone 5 -->
+    <after css:content-children="#global_statusmessage" css:theme="#globalstatusmessage" />
 
   </rules>
 </rules>

--- a/plonetheme/blueberry/standard/theme/rules.xml
+++ b/plonetheme/blueberry/standard/theme/rules.xml
@@ -144,7 +144,10 @@
     <drop attributes="alt" content="//a[@id='portal-logo']/img[@alt='']" />
     <drop attributes="title" content="//a[@id='portal-logo']/img[@title='']" />
 
+    <!-- status messages from Plone 4 and ftw.globalstatusmessage -->
     <replace css:content="#globalstatusmessage" css:theme="#globalstatusmessage" />
+    <!-- status messages from Plone 5 -->
+    <after css:content-children="#global_statusmessage" css:theme="#globalstatusmessage" />
 
   </rules>
 </rules>


### PR DESCRIPTION
These were hidden for 'Mail sent' message in bl.web's addressblock contact view and the standard 'Item copied' message from the Copy action, probably a lot more too.