### PR TITLE
Fix plone 5 pagination styles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.11.2 (unreleased)
 -------------------
 
+- Fix plone 5 pagination styles [mathias.leimgruber]
 - Fix footer rule, since the markup is different. [mathias.leimgruber]
 - Restore globalstatusmessages which were hidden for (at least some) parts of Plone 5. [djowett-ftw]
 

--- a/plonetheme/blueberry/scss/batching.scss
+++ b/plonetheme/blueberry/scss/batching.scss
@@ -1,4 +1,10 @@
-#content .listingBar, .listingBar {
+#content .listingBar, .listingBar,
+#content .pagination, .pagination {
+
+  ul {
+    @include ul('inline');
+  }
+
   margin: 0.5em 0;
 
   .previous {
@@ -12,7 +18,18 @@
   a {
     @include button();
   }
+
   a, span {
     line-height: normal;
+  }
+
+  .active {
+    @include button($disabled: true); 
+    color: black;
+  }
+
+  .label {
+    font-weight: normal;
+    padding-bottom: 0;
   }
 }


### PR DESCRIPTION
Plone 4:
<img width="1229" alt="Screen Shot 2020-05-28 at 15 04 11" src="https://user-images.githubusercontent.com/437933/83145224-c40ef380-a0f4-11ea-95aa-aa9c089c8035.png">

Plone 5.1:
Looks event better, since there is a class on the active element.
<img width="912" alt="Screen Shot 2020-05-28 at 15 03 58" src="https://user-images.githubusercontent.com/437933/83145269-d4bf6980-a0f4-11ea-9470-ef665551451f.png">


The arrows are no longer visible, since they are no longer in the DOM (which is IMHO fine)