### PR TITLE
Style globalstatusmessage

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 -------------------
 
 - Fix plone 5 pagination styles [mathias.leimgruber]
+- Add slightly customized globalstatusmessage viewlet for plone 5.1 [mathias.leimgruber]
 - Fix footer rule, since the markup is different. [mathias.leimgruber]
 - Restore globalstatusmessages which were hidden for (at least some) parts of Plone 5. [djowett-ftw]
 

--- a/plonetheme/blueberry/scss/messages.scss
+++ b/plonetheme/blueberry/scss/messages.scss
@@ -51,5 +51,56 @@ dl.portalMessage, #content dl.portalMessage {
     border-top-right-radius: $border-radius-primary;
     border-bottom-right-radius: $border-radius-primary;
   }
+}
 
+
+
+body.pat-plone {
+  @mixin portal-message($portalmessage-dt-color, $typeclass:null) {
+    &.#{$typeclass} .title {
+      background-color: $portalmessage-dt-color;
+      border: 1px solid darken($portalmessage-dt-color, 15%);
+      @include auto-text-color($portalmessage-dt-color);
+    }
+  }
+
+  .portalMessage, #content .portalMessage {
+    display: block;
+    margin: $margin-vertical 0;
+
+    .title {
+      padding: $padding-vertical / 2 $padding-horizontal / 2;
+      display: table-cell;
+      font-weight: normal;
+      border-top-left-radius: $border-radius-primary;
+      border-bottom-left-radius: $border-radius-primary;
+      white-space: nowrap;
+    }
+
+    @include portal-message($portalmessage-undefined-color, portalMessage);
+    @include portal-message($portalmessage-info-color, info);
+    @include portal-message($portalmessage-warning-color, warning);
+    @include portal-message($portalmessage-error-color, error);
+
+    .content {
+      padding: $padding-vertical / 2 $padding-horizontal / 2;
+      display: table-cell;
+      width: 100%;
+      background-color: $portalmessage-message-color;
+      border: 1px solid $portalmessage-border-color;
+      border-left-width: 0;
+      border-top-right-radius: $border-radius-primary;
+      border-bottom-right-radius: $border-radius-primary;
+    }
+  }
+
+  /* Additional specificity for when status is shown inside #content */
+  #content .portalMessage strong {
+    margin: 0 $margin-horizontal / 2 0 0;
+    padding: $margin-vertical $margin-horizontal;
+  }
+
+  #header > .portalMessage {
+    margin: $margin-vertical $margin-horizontal;
+  }
 }

--- a/plonetheme/blueberry/viewlets/configure.zcml
+++ b/plonetheme/blueberry/viewlets/configure.zcml
@@ -12,4 +12,14 @@
         permission="zope2.View"
         layer="plonetheme.blueberry.interfaces.IBlueberryLayer"
         />
+
+    <browser:viewlet
+        zcml:condition="have plone-5"
+        name="plone.globalstatusmessage"
+        manager="plone.app.layout.viewlets.interfaces.IGlobalStatusMessage"
+        class=".globalstatusmessage.BlueberryGlobalStatusMessage"
+        permission="zope2.View"
+        layer="plonetheme.blueberry.interfaces.IBlueberryLayer"
+        />
+
 </configure>

--- a/plonetheme/blueberry/viewlets/globalstatusmessage.pt
+++ b/plonetheme/blueberry/viewlets/globalstatusmessage.pt
@@ -1,0 +1,14 @@
+<tal:statusmsg tal:define="messages view/messages"
+    tal:repeat="message messages">
+
+    <div tal:define="mtype message/type | nothing;"
+        tal:attributes="class string:portalMessage ${mtype};">
+        <strong
+            i18n:translate="" tal:content="python:mtype.capitalize()">Info</strong>
+        <span class="content"
+            tal:replace="message/message | nothing" i18n:translate="">
+            The status message.
+        </span>
+    </div>
+
+</tal:statusmsg>

--- a/plonetheme/blueberry/viewlets/globalstatusmessage.pt
+++ b/plonetheme/blueberry/viewlets/globalstatusmessage.pt
@@ -3,10 +3,10 @@
 
     <div tal:define="mtype message/type | nothing;"
         tal:attributes="class string:portalMessage ${mtype};">
-        <strong
+        <strong class="title"
             i18n:translate="" tal:content="python:mtype.capitalize()">Info</strong>
         <span class="content"
-            tal:replace="message/message | nothing" i18n:translate="">
+            tal:content="message/message | nothing" i18n:translate="">
             The status message.
         </span>
     </div>

--- a/plonetheme/blueberry/viewlets/globalstatusmessage.py
+++ b/plonetheme/blueberry/viewlets/globalstatusmessage.py
@@ -1,0 +1,6 @@
+from plone.app.layout.viewlets.globalstatusmessage import GlobalStatusMessage
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class BlueberryGlobalStatusMessage(GlobalStatusMessage):
+    index = ViewPageTemplateFile('globalstatusmessage.pt')


### PR DESCRIPTION
- Add title class
- Don not replace the message content - don't lose the class attr.


New look:
<img width="1206" alt="Screen Shot 2020-05-29 at 11 14 55" src="https://user-images.githubusercontent.com/437933/83243855-caf24080-a19e-11ea-919e-1ce3488e072e.png">

<img width="694" alt="Screen Shot 2020-05-29 at 11 15 43" src="https://user-images.githubusercontent.com/437933/83243851-c9287d00-a19e-11ea-8bb2-ca7ecabba8bb.png">
