### PR TITLE
Add basetag in plone 5

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Add some minimal easyform styles. [mathias.leimgruber]
 - Fix footer rule, since the markup is different. [mathias.leimgruber]
 - Restore globalstatusmessages which were hidden for (at least some) parts of Plone 5. [djowett-ftw]
+- Add basetag. [busykoala]
 
 
 1.11.1 (2019-07-05)

--- a/plonetheme/blueberry/tests/test_basetag_viewlet.py
+++ b/plonetheme/blueberry/tests/test_basetag_viewlet.py
@@ -1,0 +1,15 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from plonetheme.blueberry.tests import FunctionalTestCase
+
+
+class TestBaseTagViewlet(FunctionalTestCase):
+
+    @browsing
+    def test_base_tag_has_trailing_slash(self, browser):
+        self.grant('Manager')
+        folder = create(Builder('folder').titled(u'The Folder'))
+        browser.login().open(folder)
+        self.assertEqual({'href': 'http://nohost/plone/the-folder/'},
+                         dict(browser.css('base').first.attrib))

--- a/plonetheme/blueberry/viewlets/basetag.py
+++ b/plonetheme/blueberry/viewlets/basetag.py
@@ -1,0 +1,9 @@
+from plone.app.layout.viewlets.common import ViewletBase
+
+
+class BaseTagViewlet(ViewletBase):
+
+    template = '<base href="{}" />'
+
+    def index(self):
+        return self.template.format(self.context.absolute_url() + '/')

--- a/plonetheme/blueberry/viewlets/configure.zcml
+++ b/plonetheme/blueberry/viewlets/configure.zcml
@@ -22,4 +22,13 @@
         layer="plonetheme.blueberry.interfaces.IBlueberryLayer"
         />
 
+    <browser:viewlet
+        zcml:condition="have plone-5"
+        name="blueberry.basetag"
+        manager="plone.app.layout.viewlets.interfaces.IHtmlHead"
+        class=".basetag.BaseTagViewlet"
+        permission="zope2.View"
+        layer="plonetheme.blueberry.interfaces.IBlueberryLayer"
+        />
+
 </configure>


### PR DESCRIPTION
See https://github.com/OneGov/plonetheme.onegov/pull/231 for more info why this is necessary.

See img below as a reference:
![image](https://user-images.githubusercontent.com/29920936/83523890-17ad8280-a4e3-11ea-9a35-2f546968b316.png)
