### PR TITLE
Fix position of user menu on the left expanded and compact.

### DIFF
--- a/plonetheme/blueberry/scss/site/editbar.scss
+++ b/plonetheme/blueberry/scss/site/editbar.scss
@@ -48,3 +48,9 @@
 body[class*="plone-toolbar"] #edit-bar {
   position: absolute;
 }
+
+.plone-toolbar-left #edit-zone {
+  nav > ul#personal-bar-container ul {
+    left: 0;
+  }
+}


### PR DESCRIPTION
New:

<img width="401" alt="Screen Shot 2020-06-10 at 14 32 00" src="https://user-images.githubusercontent.com/437933/84268409-df7ff280-ab27-11ea-9373-9da1fd92c154.png">
<img width="361" alt="Screen Shot 2020-06-10 at 14 31 51" src="https://user-images.githubusercontent.com/437933/84268413-e149b600-ab27-11ea-8ad6-0c90d8a4666c.png">
