### PR TITLE
Fix select2 css display issue.

### DIFF
--- a/plonetheme/blueberry/scss/widgets/select2.scss
+++ b/plonetheme/blueberry/scss/widgets/select2.scss
@@ -73,3 +73,7 @@
 .select2-container.select2-container--default .select2-results > .select2-results__options {
   max-height: 400px;
 }
+
+.select2-search__field {
+  width: 100% !important;
+}


### PR DESCRIPTION
We have select2 v3 css and select2 v4 css.
<img width="594" alt="Screen Shot 2020-06-11 at 14 17 52" src="https://user-images.githubusercontent.com/437933/84384630-8b8c1100-abee-11ea-843b-e4e373d9250b.png">
<img width="419" alt="Screen Shot 2020-06-11 at 14 17 25" src="https://user-images.githubusercontent.com/437933/84384633-8cbd3e00-abee-11ea-840c-015049e5accf.png">



Before:
<img width="486" alt="Screen Shot 2020-06-11 at 14 19 30" src="https://user-images.githubusercontent.com/437933/84384663-96df3c80-abee-11ea-9dc4-b37f96d246ad.png">
