### PR TITLE
Fix accesskeys viewlet for plone 5.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.11.2 (unreleased)
 -------------------
 
+- Fix accesskeys viewlet for plone 5. [mathias.leimgruber]
 - Fix datagrid integration for plone 5. [mathias.leimgruber]
 - Fix body attributes. [mathias.leimgruber]
 - Fix Checkbox display issue. [mathias.leimgruber]

--- a/plonetheme/blueberry/viewlets/accesskeys.py
+++ b/plonetheme/blueberry/viewlets/accesskeys.py
@@ -3,7 +3,7 @@ from plone.app.layout.viewlets import common
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 
-class BlueberrySkipLinksViewlet(common.SkipLinksViewlet):
+class BlueberrySkipLinksViewlet(common.ViewletBase):
     index = ViewPageTemplateFile('accesskeys.pt')
 
     def update(self):


### PR DESCRIPTION
`SkipLinksViewlet` no longer exists. 