### PR TITLE
Show login link in Plone 5 as previously in Plone 4

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.11.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Show login link in Plone 5 as previously in Plone 4 [Nachtalb]
 
 
 1.11.4 (2020-11-13)

--- a/plonetheme/blueberry/government/theme/rules.xml
+++ b/plonetheme/blueberry/government/theme/rules.xml
@@ -23,7 +23,14 @@
     <before css:content="#portal-header > h2.hiddenStructure" css:theme="#portal-globalnav"/>
 
     <replace css:content="#portal-searchbox" css:theme="#portal-searchbox" />
-    <replace css:content="#portal-personaltools-wrapper" css:theme="#portal-personaltools-wrapper" />
+
+    <!-- User actions rendered in Plone 4 and 5 -->
+    <rules if-content="not(//body[contains(@class, 'plone-5')])">
+      <replace css:content="#portal-personaltools-wrapper" css:theme="#portal-personaltools-wrapper" />
+    </rules>
+    <rules if-content="//body[contains(@class, 'plone-5')]">
+      <replace css:content="#portal-anontools" css:theme="#portal-personaltools-wrapper" />
+    </rules>
 
     <rules if-content="not(//*[@id='portal-languageselector-wrapper'])">
         <replace css:content="#portal-languageselector" css:theme="#portal-languageselector" />

--- a/plonetheme/blueberry/marketing/theme/rules.xml
+++ b/plonetheme/blueberry/marketing/theme/rules.xml
@@ -23,7 +23,13 @@
     <before css:content="#portal-header > h2.hiddenStructure" css:theme="#portal-globalnav"/>
 
     <replace css:content="#portal-searchbox" css:theme="#portal-searchbox" />
-    <replace css:content="#portal-personaltools-wrapper" css:theme="#portal-personaltools-wrapper" />
+    <!-- User actions rendered in Plone 4 and 5 -->
+    <rules if-content="not(//body[contains(@class, 'plone-5')])">
+      <replace css:content="#portal-personaltools-wrapper" css:theme="#portal-personaltools-wrapper" />
+    </rules>
+    <rules if-content="//body[contains(@class, 'plone-5')]">
+      <replace css:content="#portal-anontools" css:theme="#portal-personaltools-wrapper" />
+    </rules>
 
     <rules if-content="not(//*[@id='portal-languageselector-wrapper'])">
         <replace css:content="#portal-languageselector" css:theme="#portal-languageselector" />

--- a/plonetheme/blueberry/scss/site/portaltop.scss
+++ b/plonetheme/blueberry/scss/site/portaltop.scss
@@ -8,14 +8,16 @@
   @include cell();
   @include gridposition(0);
   @include gridwidth(16);
-  .actionMenuHeader > a {
+  .actionMenuHeader > a,
+  #portal-anontools a  {
     @include auto-link-color($color-primary);
     padding-right: 0;
     padding-left: $padding-horizontal / 2;
   }
 }
 
-#portal-personaltools-wrapper {
+#portal-personaltools-wrapper,
+#portal-anontools {
   float: right;
   padding-left: $padding-horizontal;
   > ul {

--- a/plonetheme/blueberry/scss/style/government.scss
+++ b/plonetheme/blueberry/scss/style/government.scss
@@ -45,7 +45,8 @@
     }
   }
 
-  #anon-personalbar a {
+  #anon-personalbar a,
+  #portal-top #portal-anontools a {
     @include auto-link-color($color-page-background);
   }
 

--- a/plonetheme/blueberry/standard/theme/rules.xml
+++ b/plonetheme/blueberry/standard/theme/rules.xml
@@ -23,7 +23,13 @@
     <before css:content="#portal-header > h2.hiddenStructure" css:theme="#portal-globalnav"/>
 
     <replace css:content="#portal-searchbox" css:theme="#portal-searchbox" />
-    <replace css:content="#portal-personaltools-wrapper" css:theme="#portal-personaltools-wrapper" />
+    <!-- User actions rendered in Plone 4 and 5 -->
+    <rules if-content="not(//body[contains(@class, 'plone-5')])">
+      <replace css:content="#portal-personaltools-wrapper" css:theme="#portal-personaltools-wrapper" />
+    </rules>
+    <rules if-content="//body[contains(@class, 'plone-5')]">
+      <replace css:content="#portal-anontools" css:theme="#portal-personaltools-wrapper" />
+    </rules>
 
     <rules if-content="not(//*[@id='portal-languageselector-wrapper'])">
         <replace css:content="#portal-languageselector" css:theme="#portal-languageselector" />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9467802/101890775-75610c80-3ba1-11eb-826a-bf1d727632a1.png)

Looks like it did in Plone 4 in all three themes. 